### PR TITLE
Django migration UX improvements

### DIFF
--- a/tests/native/core/test_tools/test_migrations/test_mark.py
+++ b/tests/native/core/test_tools/test_migrations/test_mark.py
@@ -1,0 +1,90 @@
+import pytest
+from mock import patch
+from transifex.native.tools.migrations.mark import (
+    MARK_PROOFREAD_FILE, MARK_PROOFREAD_STRING, MarkLowConfidenceFilesPolicy,
+    MarkLowConfidenceStringsPolicy, MarkPolicy, NoopMarkPolicy)
+from transifex.native.tools.migrations.models import (Confidence,
+                                                      FileMigration,
+                                                      StringMigration)
+
+
+def test_base_class_policy_returns_false():
+    policy = NoopMarkPolicy()
+    assert policy.mark_file(_file()) is False
+    assert policy.mark_string(_string()) is False
+
+
+@patch('transifex.native.tools.migrations.mark.Color.echo')
+@patch('transifex.native.tools.migrations.mark.mark_string')
+def test_low_file_policy_marks_low_confidence_files(mock_mark_string,
+                                                    mock_echo):
+    # Create a file migration with 3 strings,
+    # the middle one with low confidence
+    policy = MarkLowConfidenceFilesPolicy()
+    policy.set_comment_format('# {}')
+    file_migration = _file()
+    file_migration.add_string(_string(Confidence.HIGH))
+    file_migration.add_string(_string(Confidence.LOW))
+    file_migration.add_string(_string(Confidence.HIGH))
+
+    # A proofread mark should have been added before the first string,
+    # as the files policy adds a mark at the file top
+    policy.mark_file(file_migration)
+    mock_mark_string.assert_called_once_with(
+        file_migration.strings[0],
+        '# {}',
+        MARK_PROOFREAD_FILE,
+    )
+
+    # Calls to mark_string() of a files policy should not mark anything
+    mock_mark_string.reset_mock()
+    policy.mark_string(file_migration.strings[1])
+    assert mock_mark_string.called is False
+
+
+@patch('transifex.native.tools.migrations.mark.Color.echo')
+@patch('transifex.native.tools.migrations.mark.mark_string')
+def test_low_string_policy_marks_low_confidence_strings(mock_mark_string,
+                                                        mock_echo):
+    # Create a file migration with 3 strings,
+    # two of which have low confidence
+    policy = MarkLowConfidenceStringsPolicy()
+    policy.set_comment_format('<!-- {} -->')
+    file_migration = _file()
+    file_migration.add_string(_string(Confidence.HIGH))
+    file_migration.add_string(_string(Confidence.LOW))
+    file_migration.add_string(_string(Confidence.LOW))
+
+    policy.mark_file(file_migration)
+    assert mock_mark_string.called is False
+
+    for string_migration in file_migration.strings:
+        policy.mark_string(string_migration)
+
+    assert mock_mark_string.call_args_list[0][0] == (
+        file_migration.strings[1],
+        '<!-- {} -->',
+        MARK_PROOFREAD_STRING,
+    )
+    assert mock_mark_string.call_args_list[1][0] == (
+        file_migration.strings[2],
+        '<!-- {} -->',
+        MARK_PROOFREAD_STRING,
+    )
+
+
+def test_set_comment_format_exception_for_wrong_format():
+    # An exception should be raised if the given format does not include {}
+    policy = MarkPolicy()
+    with pytest.raises(ValueError):
+        policy.set_comment_format('{')
+
+
+def _string(confidence=Confidence.HIGH):
+    """Return a sample StringMigration object for testing."""
+    return StringMigration('original', 'new', confidence)
+
+
+def _file():
+    """Return a sample FileMigration object for testing."""
+    return FileMigration('filename', 'content')

--- a/tests/native/core/test_tools/test_migrations/test_save.py
+++ b/tests/native/core/test_tools/test_migrations/test_save.py
@@ -4,7 +4,7 @@ from mock import mock_open, patch
 from transifex.native.tools.migrations.models import (FileMigration,
                                                       StringMigration)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
-                                                    InPlaceSavePolicy,
+                                                    ReplaceSavePolicy,
                                                     NewFileSavePolicy,
                                                     NoopSavePolicy, SavePolicy)
 
@@ -56,7 +56,7 @@ def test_backup_policy_writes_to_original_file_and_takes_backup():
 
 
 def test_in_place_policy_writes_to_original_file():
-    policy = InPlaceSavePolicy()
+    policy = ReplaceSavePolicy()
     m = mock_open()
     with patch(BUILTINS_MODULE + ".open", m, create=True):
         saved, error_type = policy.save_file(_file_migration())

--- a/tests/native/core/test_tools/test_migrations/test_save.py
+++ b/tests/native/core/test_tools/test_migrations/test_save.py
@@ -4,9 +4,10 @@ from mock import mock_open, patch
 from transifex.native.tools.migrations.models import (FileMigration,
                                                       StringMigration)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
-                                                    ReplaceSavePolicy,
                                                     NewFileSavePolicy,
-                                                    NoopSavePolicy, SavePolicy)
+                                                    NoopSavePolicy,
+                                                    ReplaceSavePolicy,
+                                                    SavePolicy)
 
 BUILTINS_MODULE = 'builtins' if sys.version_info >= (3, 0) else '__builtin__'
 

--- a/tests/native/django/test_commands/test_migratetransifex.py
+++ b/tests/native/django/test_commands/test_migratetransifex.py
@@ -8,12 +8,11 @@ from tests.native.django.test_tools.test_migrations.test_templatetags import (
 from transifex.native.django.management.commands.migratetransifex import \
     Command
 from transifex.native.django.management.common import TranslatableFile
-from transifex.native.parsing import SourceString
 from transifex.native.tools.migrations.review import (FileReviewPolicy,
                                                       NoopReviewPolicy,
                                                       StringReviewPolicy)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
-                                                    InPlaceSavePolicy,
+                                                    ReplaceSavePolicy,
                                                     NewFileSavePolicy,
                                                     NoopSavePolicy)
 
@@ -194,7 +193,7 @@ def test_replace_save_string_review(mock_find_files, mock_read,
     ]
     command = Command()
     call_command(command, save_policy='replace', review_policy='string')
-    assert isinstance(command.save_policy, InPlaceSavePolicy)
+    assert isinstance(command.save_policy, ReplaceSavePolicy)
     assert isinstance(command.review_policy, StringReviewPolicy)
 
     assert mock_prompt_file.call_count == 0

--- a/transifex/common/console.py
+++ b/transifex/common/console.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
 import click
+
+from transifex.native.rendering import StringRenderer
 
 
 class Color:
@@ -17,14 +20,15 @@ class Color:
         """Format the given string, adding color support."""
         return (
             string.replace('[high]', Color.HIGHLIGHT)
-            .replace('[cyan]', Color.CYAN)
             .replace('[end]', Color.END)
+            .replace('[cyan]', Color.CYAN)
+            .replace('[file]', Color.CYAN)
             .replace('[green]', Color.GREEN)
             .replace('[red]', Color.RED)
             .replace('[opt]', Color.PINK)
             .replace('[warn]', Color.PINK)
             .replace('[prompt]', Color.YELLOW)
-            .replace('[file]', Color.CYAN)
+            .replace('[yel]', Color.YELLOW)
         )
 
     @staticmethod
@@ -58,3 +62,26 @@ def prompt(prompt_msg, description=None, default=None, new_line=False, vtype=Non
             description=description))
 
     return click.prompt(prompt_msg, default=default, type=(vtype or str))
+
+
+def pluralized(one, other, cnt_value):
+    """Render an ICU pluralized string with the given parameters.
+
+    :param unicode one: the string for singular
+    :param unicode other: the string for plural
+    :param int cnt_value: the value of the plural counter variable
+    :return: a rendered string that has taken into account the given
+    :rtype: unicode
+    """
+    icu_string = '{cnt, plural, one {[one]} other {[other]}}'\
+        .replace('[one]', one)\
+        .replace('[other]', other)
+
+    return StringRenderer.render(
+        icu_string,
+        string_to_render=icu_string,
+        language_code='en',
+        escape=False,
+        missing_policy=None,
+        cnt=cnt_value,
+    )

--- a/transifex/common/console.py
+++ b/transifex/common/console.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
-import click
 
+import click
 from transifex.native.rendering import StringRenderer
 
 
@@ -8,7 +8,7 @@ class Color:
     """Convenience class for adding color to console output."""
 
     CYAN = '\033[36m'
-    HIGHLIGHT = '\033[1m'
+    WHITE_BOLD = '\033[1m'
     GREEN = '\033[32m'
     PINK = '\033[91m'
     RED = '\033[31m'
@@ -19,15 +19,18 @@ class Color:
     def format(string):
         """Format the given string, adding color support."""
         return (
-            string.replace('[high]', Color.HIGHLIGHT)
-            .replace('[end]', Color.END)
-            .replace('[cyan]', Color.CYAN)
+            # Context
+            string.replace('[high]', Color.WHITE_BOLD)
+            .replace('[warn]', Color.PINK)
             .replace('[file]', Color.CYAN)
+            .replace('[opt]', Color.PINK)
+            .replace('[prompt]', Color.YELLOW)
+            .replace('[end]', Color.END)  # closing tag for any color tag
+
+            # Colors
+            .replace('[cyan]', Color.CYAN)
             .replace('[green]', Color.GREEN)
             .replace('[red]', Color.RED)
-            .replace('[opt]', Color.PINK)
-            .replace('[warn]', Color.PINK)
-            .replace('[prompt]', Color.YELLOW)
             .replace('[yel]', Color.YELLOW)
         )
 
@@ -35,12 +38,6 @@ class Color:
     def echo(string):
         """Print to the console with color support."""
         print(Color.format(string))
-
-
-def display(*messages):
-    """Print all given strings respecting any color markup."""
-    for msg in messages:
-        Color.echo(msg)
 
 
 def prompt(prompt_msg, description=None, default=None, new_line=False, vtype=None):

--- a/transifex/native/django/management/commands/migratetransifex.py
+++ b/transifex/native/django/management/commands/migratetransifex.py
@@ -9,15 +9,19 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import BaseCommand
 from django.core.management.utils import handle_extensions
 from django.utils.functional import cached_property
-
 from transifex.native.django.management.common import TranslatableFile
-from transifex.native.tools.migrations.review import (FileReviewPolicy,
-    LowConfidenceFileReviewPolicy, LowConfidenceStringReviewPolicy,
-    NoopReviewPolicy, StringReviewPolicy)
+from transifex.native.django.tools.migrations.templatetags import \
+    DjangoTagMigrationBuilder
+from transifex.native.tools.migrations.execution import (REVIEW_POLICY_OPTIONS,
+                                                         SAVE_POLICY_OPTIONS,
+                                                         MigrationExecutor)
+from transifex.native.tools.migrations.review import (
+    FileReviewPolicy, LowConfidenceFileReviewPolicy,
+    LowConfidenceStringReviewPolicy, NoopReviewPolicy, StringReviewPolicy)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
-                                                    ReplaceSavePolicy,
                                                     NewFileSavePolicy,
-                                                    NoopSavePolicy)
+                                                    NoopSavePolicy,
+                                                    ReplaceSavePolicy)
 
 SAVE_POLICY_OPTIONS = {
     NoopSavePolicy.name: 'no changes will be saved\n',
@@ -26,7 +30,8 @@ SAVE_POLICY_OPTIONS = {
     BackupSavePolicy.name: 'migrated content will be saved directly in the '
                            'original file path, and a backup will also be '
                            'saved in <filename>.<extension>.bak\n',
-    ReplaceSavePolicy: 'migrated content will be saved in the original file',
+    ReplaceSavePolicy.name: 'migrated content will be saved in the original '
+                            'file',
 }
 
 REVIEW_POLICY_OPTIONS = {
@@ -44,9 +49,6 @@ REVIEW_POLICY_OPTIONS = {
                                           'string that has a low migration '
                                           'confidence\n',
 }
-from transifex.native.django.tools.migrations.templatetags import DjangoTagMigrationBuilder
-from transifex.native.tools.migrations.execution import (MigrationExecutor,
-    REVIEW_POLICY_OPTIONS, SAVE_POLICY_OPTIONS)
 
 EXTENSIONS = ['html', 'txt', 'py']
 
@@ -85,6 +87,13 @@ class Command(BaseCommand):
             '--review', dest='review_policy', default='file',
             help=(
                 'Determines where the migrated content will be saved: \n' +
+                pretty_options(REVIEW_POLICY_OPTIONS)
+            ),
+        )
+        parser.add_argument(
+            '--mark', dest='mark_policy', default='none',
+            help=(
+                'Determines if anything gets marked for proofreading: \n' +
                 pretty_options(REVIEW_POLICY_OPTIONS)
             ),
         )

--- a/transifex/native/django/management/commands/migratetransifex.py
+++ b/transifex/native/django/management/commands/migratetransifex.py
@@ -3,13 +3,15 @@ from __future__ import unicode_literals
 import fnmatch
 import io
 import os
+import sys
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import BaseCommand
 from django.core.management.utils import handle_extensions
 from django.utils.functional import cached_property
-from transifex.common.console import Color
+
+from transifex.common.console import Color, prompt, pluralized
 from transifex.native.django.management.common import TranslatableFile
 from transifex.native.django.tools.migrations.templatetags import \
     DjangoTagMigrationBuilder
@@ -17,35 +19,39 @@ from transifex.native.tools.migrations.models import Confidence
 from transifex.native.tools.migrations.review import (
     REVIEW_ACCEPT_ALL, REVIEW_REJECT_ALL, FileReviewPolicy,
     LowConfidenceFileReviewPolicy, LowConfidenceStringReviewPolicy,
-    NoopReviewPolicy, StringReviewPolicy, prompt_to_start)
+    NoopReviewPolicy, StringReviewPolicy, REVIEW_EXIT)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
-                                                    InPlaceSavePolicy,
+                                                    ReplaceSavePolicy,
                                                     NewFileSavePolicy,
                                                     NoopSavePolicy)
 
 SAVE_POLICY_OPTIONS = {
-    'dry-run': 'no changes will be saved\n',
-    'new': 'migrated content will be saved in a new file, '
-           'named <filename>__native.<extension>\n',
-    'backup': 'migrated content will be saved directly in the original '
-              'file path, and a backup will also be saved '
-              'in <filename>.<extension>.bak\n',
-    'replace': 'migrated content will be saved in the original file',
+    NoopSavePolicy.name: 'no changes will be saved\n',
+    NewFileSavePolicy.name: 'migrated content will be saved in a new file, '
+                            'named <filename>__native.<extension>\n',
+    BackupSavePolicy.name: 'migrated content will be saved directly in the '
+                           'original file path, and a backup will also be '
+                           'saved in <filename>.<extension>.bak\n',
+    ReplaceSavePolicy: 'migrated content will be saved in the original file',
 }
 
 REVIEW_POLICY_OPTIONS = {
-    'none': 'everything will be done automatically without '
-            'having a chance to review anything\n',
-    'file': 'you get a chance to review each migrated file '
-            'before it is saved\n',
-    'string': 'you get a chance to review each string of each file '
-              'before the file is saved\n',
-    'file-low': 'you get a chance to review each migrated file '
-                'that includes at least one string that has '
-                'a low migration confidence\n',
-    'string-low': 'you get a chance to review each string '
-                  'that has a low migration confidence\n',
+    NoopReviewPolicy.name: 'everything will be done automatically without '
+                           'having a chance to review anything\n',
+    FileReviewPolicy.name: 'you get a chance to review each migrated file '
+                           'before it is saved\n',
+    StringReviewPolicy.name: 'you get a chance to review each string of each '
+                             'file before the file is saved\n',
+    LowConfidenceFileReviewPolicy.name: 'you get a chance to review each '
+                                        'migrated file that includes at least '
+                                        'one string that has a low migration '
+                                        'confidence\n',
+    LowConfidenceStringReviewPolicy.name: 'you get a chance to review each '
+                                          'string that has a low migration '
+                                          'confidence\n',
 }
+
+EXTENSIONS = ['html', 'txt', 'py']
 
 
 def pretty_options(options_dict):
@@ -95,19 +101,21 @@ class Command(BaseCommand):
         self.ignore_patterns = []
         self.verbosity = options['verbosity']
         self.path = options['path']
+
+        options['files'] = set(options['files'] or [])
         self.files = options['files']
 
         self.save_policy = self._create_save_policy(options['save_policy'])
         self.review_policy = self._create_review_policy(
             options['review_policy'])
 
-        self.extensions = handle_extensions(['html', 'txt', 'py'])
+        self.extensions = handle_extensions(EXTENSIONS)
         self.stats = {
             'processed_files': 0, 'migrations': [], 'saved': [], 'errors': [],
         }
 
         # Show an intro message
-        self._show_intro(options)
+        _show_intro(options)
 
         # If specific files are defined, use those
         if self.files:
@@ -120,37 +128,12 @@ class Command(BaseCommand):
         else:
             files = self._find_files(self.path)
 
+        # Ask the user for permission to continue
+        _prompt_to_start(len(files), options)
+
         # Execute the migration
         self.django_migration_builder = DjangoTagMigrationBuilder()
         self.migrate_files(files)
-
-    def _show_intro(self, options):
-        """Show an introductory message to help the user understand what is going on.
-
-        :param dict options: the configuration options of the command
-        """
-        Color.echo(
-            '[high]'
-            '\n####################################################################\n'
-            'Running migration from Django i18n syntax to Transifex Native syntax\n'
-            '[end]'
-            'This migration is idempotent, so its output should not change if run\n'
-            'multiple times.'
-        )
-        Color.echo('\n[high]Configuration:[end]')
-        Color.echo('- [opt]Path:[end] [file]{}[end]'.format(self.path))
-        Color.echo(
-            '- [opt]Save policy:[end] [high]{}[end] -> {}'.format(
-                options['save_policy'],
-                SAVE_POLICY_OPTIONS[options['save_policy']],
-            ).strip()
-        )
-        Color.echo(
-            '- [opt]Review policy:[end] [high]{}[end] -> {}'.format(
-                options['review_policy'],
-                REVIEW_POLICY_OPTIONS[options['review_policy']],
-            ).strip()
-        )
 
     def migrate_files(self, files):
         """Search all related files, detect Django i18n translate hooks and migrate
@@ -159,26 +142,32 @@ class Command(BaseCommand):
         :param list files: a list of TranslatableFile objects
         """
         files_total = len(files)
-        prompt_to_start(files_total)
+
+        accept_remaining_files = False
+        exit_migration = False
 
         # Loop through each file, migrate, ask for user review if applicable,
         # save to disk if applicable
-        accept_remaining_files = False
         for file_cnt, translatable_file in enumerate(files):
+            if exit_migration:
+                break
+
             _, extension = os.path.splitext(translatable_file.file)
             comment_format = '# {}\n' if extension == '.py' else '<!-- {} -->\n'
             self.review_policy.set_comment_format(comment_format)
 
             Color.echo(
-                '\n---- [{cnt}/{total}] Migrating [file]{path}[end]...'.format(
+                '\n---- '
+                '[[high]{cnt}[end]/[high]{total}[end]] '
+                'Migrating [file]{path}[end]...'.format(
                     path=translatable_file.path,
                     cnt=file_cnt + 1,
                     total=files_total,
                 )
             )
+            self.stats['processed_files'] += 1
             file_migration = self._migrate_file(translatable_file)
             if not file_migration:
-                self.stats['processed_files'] += 1
                 continue
 
             modified_strings = file_migration.modified_strings
@@ -186,11 +175,20 @@ class Command(BaseCommand):
             total_low_confidence = len(
                 [x for x in modified_strings if x.confidence == Confidence.LOW]
             )
+            msg = pluralized(
+                '[warn]1[end] [prompt]string was modified[end]',
+                '[warn]{cnt}[end] [prompt]strings were modified[end]',
+                total_modified,
+            )
             Color.echo(
-                '[prompt]{strings} strings were modified '
-                ' ([warn]{low}[end] with LOW confidence)[end]'.format(
-                    strings=total_modified,
-                    low=total_low_confidence,
+                '{msg}{confidence}'.format(
+                    msg=msg,
+                    confidence=(
+                        ' ([warn]{low}[end] with low confidence)'.format(
+                            low=total_low_confidence,
+                        )
+                        if total_low_confidence else ''
+                    )
                 )
             )
             if not total_modified:
@@ -202,13 +200,13 @@ class Command(BaseCommand):
             # additional filters, e.g. only prompt for strings with low
             # confidence
             if self.review_policy.should_review_strings():
-                reject_remaining = False
+                reject_remaining_strings = False
                 for string_index in range(total_modified):
                     string_migration = modified_strings[string_index]
 
                     # The rest of the string test_migrations should be reverted
                     # based on the user's choice
-                    if reject_remaining:
+                    if reject_remaining_strings:
                         string_migration.revert()
 
                     # Optionally prompt the user to review the migration
@@ -229,11 +227,17 @@ class Command(BaseCommand):
                         # remaining strings. Set the flag to True, so that
                         # it will revert all changes for the rest strings
                         # in the loop
-                        if result == REVIEW_REJECT_ALL:
-                            reject_remaining = True
+                        elif result == REVIEW_REJECT_ALL:
+                            reject_remaining_strings = True
+
+                        # The user has chosen to exit the migration completely
+                        # Break to exit the outer (file) loop
+                        elif result == REVIEW_EXIT:
+                            exit_migration = True
+                            break
 
             # If the review policy says so, prompt the user for each file
-            if accept_remaining_files is False:
+            if accept_remaining_files is False and exit_migration is False:
                 result = self.review_policy.review_file(file_migration)
 
                 # The user has chosen to reject all remaining files
@@ -244,8 +248,17 @@ class Command(BaseCommand):
                 # The user has chosen to accept all remaining files
                 # Set the flag, so that the file review policy won't be used
                 # for the remaining file test_migrations
-                if result == REVIEW_ACCEPT_ALL:
+                elif result == REVIEW_ACCEPT_ALL:
                     accept_remaining_files = True
+
+                # The user has chosen to exit the migration completely
+                elif result == REVIEW_EXIT:
+                    exit_migration = True
+
+            # Skip to the results
+            # Break to exit the outer (file) loop
+            if exit_migration is True:
+                break
 
             # If the save policy says so, save the changes
             if file_migration.modified_strings:
@@ -254,7 +267,6 @@ class Command(BaseCommand):
                 saved, error_type = False, None
 
             # Update stats
-            self.stats['processed_files'] += 1
             self.stats['migrations'].append(
                 (translatable_file.path, file_migration)
             )
@@ -263,7 +275,7 @@ class Command(BaseCommand):
             elif error_type is not None:
                 self.stats['errors'].append(file_migration)
 
-        self._show_results(files)
+        _show_results(files, self.stats)
 
     def _migrate_file(self, translatable_file):
         """Extract source strings from the given file.
@@ -301,46 +313,6 @@ class Command(BaseCommand):
         return self.django_migration_builder.build_migration(
             src_data, translatable_file.path, encoding,
         )
-
-    def _show_results(self, files):
-        """Show a detailed report of how the migration went.
-
-        :param list files: a list of TranslatableFile objects
-        """
-        Color.echo('\n\n[high]Migration completed![end]')
-        Color.echo('--------------------')
-        Color.echo('[high]Total files found:[end] [warn]{}[end]'.format(
-            len(files))
-        )
-        Color.echo('[high]Total files processed:[end] [warn]{}[end]'.format(
-            self.stats['processed_files'])
-        )
-        modified = [
-            file_migration for _, file_migration in self.stats['migrations']
-            if len(file_migration.modified_strings)
-        ]
-        Color.echo('[high]Total migrations created:[end] [warn]{}[end]'.format(
-            len(modified)
-        ))
-        Color.echo('[high]Total files saved:[end] [warn]{}[end]'.format(
-            len(self.stats['saved'])
-        ))
-        Color.echo(
-            '\n'.join([
-                '- [file]{}[end]'.format(x.filename)
-                for x in self.stats['saved']
-            ])
-        )
-        Color.echo('[high]Total errors:[end] [warn]{}[end]'.format(
-            len(self.stats['errors'])
-        ))
-        Color.echo(
-            '\n'.join([
-                '- [warn]{}[end]'.format(x.filename)
-                for x in self.stats['errors']
-            ])
-        )
-        Color.echo('')
 
     def _find_files(self, root):
         """Get all files in the given root.
@@ -431,14 +403,14 @@ class Command(BaseCommand):
         :rtype: SavePolicy
         """
         policy_id = policy_id.lower()
-        if policy_id == 'dry-run':
+        if policy_id == NoopSavePolicy.name:
             return NoopSavePolicy()
-        elif policy_id == 'new':
+        elif policy_id == NewFileSavePolicy.name:
             return NewFileSavePolicy()
-        elif policy_id == 'backup':
+        elif policy_id == BackupSavePolicy.name:
             return BackupSavePolicy()
-        elif policy_id == 'replace':
-            return InPlaceSavePolicy()
+        elif policy_id == ReplaceSavePolicy.name:
+            return ReplaceSavePolicy()
 
         raise AttributeError('Invalid save policy ID={}'.format(policy_id))
 
@@ -450,15 +422,152 @@ class Command(BaseCommand):
         :return: a ReviewPolicy subclass
         :rtype: ReviewPolicy
         """
-        if policy_id == 'none':
+        if policy_id == NoopReviewPolicy.name:
             return NoopReviewPolicy()
-        elif policy_id == 'file':
+        elif policy_id == FileReviewPolicy.name:
             return FileReviewPolicy()
-        elif policy_id == 'string':
+        elif policy_id == StringReviewPolicy.name:
             return StringReviewPolicy()
-        elif policy_id == 'file-low':
+        elif policy_id == LowConfidenceFileReviewPolicy.name:
             return LowConfidenceFileReviewPolicy()
-        elif policy_id == 'string-low':
+        elif policy_id == LowConfidenceStringReviewPolicy.name:
             return LowConfidenceStringReviewPolicy()
 
         raise AttributeError('Invalid review policy ID={}'.format(policy_id))
+
+
+def _show_intro(options):
+    """Show an introductory message to help the user understand what is going on.
+
+    :param dict options: the configuration options of the command
+    """
+    Color.echo(
+        '[high]'
+        '\n####################################################################\n'
+        'Running migration from Django i18n syntax to Transifex Native syntax\n'
+        '[end]'
+        '\nThis migration is idempotent, so its output should not change if run'
+        '\nmultiple times with the same configuration.'
+    )
+    Color.echo('\n[high]Configuration:[end]')
+    if options['path']:
+        Color.echo('[opt]Path:[end] [file]{}[end]'.format(options['path']))
+    if options['files']:
+        Color.echo('[opt]Files:[end]')
+        Color.echo(
+            '\n'.join([
+                ' - [file]{}[end]'.format(x)
+                for x in options['files']
+            ])
+        )
+    Color.echo(
+        '[opt]Review policy:[end] [high]{}[end] -> {}'.format(
+            options['review_policy'],
+            REVIEW_POLICY_OPTIONS[options['review_policy']],
+        ).strip()
+    )
+    Color.echo(
+        '[opt]Save policy:[end] [high]{}[end] -> {}'.format(
+            options['save_policy'],
+            SAVE_POLICY_OPTIONS[options['save_policy']],
+        ).strip()
+    )
+
+
+def _prompt_to_start(total_files, options):
+    """Prompt the user before starting the migration.
+
+    If the user chooses to not go through with it, sys.exit() is called.
+
+    :param int total_files: the total number of files to migrate
+    :param dict options: the configuration options of the command
+    """
+    msg = pluralized(
+        'Found [warn]{cnt}[end] file to check for translatable strings.',
+        'Found [warn]{cnt}[end] files to check for translatable strings.',
+        total_files,
+    )
+    Color.echo('\n{}'.format(msg))
+
+    if not total_files:
+        Color.echo('\n[high]Migration ended.[end]')
+        sys.exit(1)
+
+    if (
+        options['save_policy'] != NoopSavePolicy.name
+        and options['review_policy'] == NoopReviewPolicy.name
+    ):
+        Color.echo(
+            '\n[warn]WARNING! The selected configuration will save all files'
+            ' automatically, without allowing you to do any reviewing first'
+            '.[end]'
+        )
+
+    while True:
+        reply = prompt(
+            Color.format(
+                '[opt](Y)[end] Yes [opt](N)[end] No'
+            ),
+            description='Are you sure you want to continue?',
+            default='N',
+        )
+        reply = reply.upper()
+        if reply == 'Y':
+            return
+        elif reply == 'N':
+            Color.echo('\n[high]Migration aborted.[end]')
+            sys.exit(1)
+
+
+def _show_results(files, stats):
+    """Show a detailed report of how the migration went.
+
+    :param list files: a list of TranslatableFile objects
+    :param dict stats: a dictionary with all statistics of the execution
+    """
+    Color.echo('\n\n[high]Migration completed![end]')
+    Color.echo('--------------------')
+    Color.echo('[high]Files found:[end] [warn]{}[end]'.format(
+        len(files))
+    )
+    Color.echo('[high]Files processed:[end] [warn]{}[end]'.format(
+        stats['processed_files'])
+    )
+
+    files_modified = 0
+    strings_modified = 0
+    for _, file_migration in stats['migrations']:
+        new_string_count = len(file_migration.modified_strings)
+        strings_modified += new_string_count
+        if new_string_count:
+            files_modified += 1
+    Color.echo(
+        '[high]File migrations created:[end] [warn]{}[end]'.format(
+            files_modified
+        )
+    )
+    Color.echo(
+        '[high]String migration inside these files: [warn]{}[end]'.format(
+            strings_modified
+        )
+    )
+    Color.echo('[high]Files saved:[end] [warn]{}[end]'.format(
+        len(stats['saved'])
+    ))
+    saved_str = '\n'.join([
+        ' - [file]{}[end]'.format(x.filename)
+        for x in stats['saved']
+    ])
+    if saved_str:
+        Color.echo(saved_str)
+    Color.echo('[high]Errors found:[end] [warn]{}[end]'.format(
+        len(stats['errors'])
+    ))
+    errors_str = '\n'.join([
+        ' - [warn]{}[end]'.format(x.filename)
+        for x in stats['errors']
+    ])
+    if errors_str:
+        Color.echo(errors_str)
+
+    Color.echo('')

--- a/transifex/native/django/management/commands/migratetransifex.py
+++ b/transifex/native/django/management/commands/migratetransifex.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import fnmatch
 import io
 import os
-import sys
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -11,15 +10,10 @@ from django.core.management import BaseCommand
 from django.core.management.utils import handle_extensions
 from django.utils.functional import cached_property
 
-from transifex.common.console import Color, prompt, pluralized
 from transifex.native.django.management.common import TranslatableFile
-from transifex.native.django.tools.migrations.templatetags import \
-    DjangoTagMigrationBuilder
-from transifex.native.tools.migrations.models import Confidence
-from transifex.native.tools.migrations.review import (
-    REVIEW_ACCEPT_ALL, REVIEW_REJECT_ALL, FileReviewPolicy,
+from transifex.native.tools.migrations.review import (FileReviewPolicy,
     LowConfidenceFileReviewPolicy, LowConfidenceStringReviewPolicy,
-    NoopReviewPolicy, StringReviewPolicy, REVIEW_EXIT)
+    NoopReviewPolicy, StringReviewPolicy)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
                                                     ReplaceSavePolicy,
                                                     NewFileSavePolicy,
@@ -50,6 +44,9 @@ REVIEW_POLICY_OPTIONS = {
                                           'string that has a low migration '
                                           'confidence\n',
 }
+from transifex.native.django.tools.migrations.templatetags import DjangoTagMigrationBuilder
+from transifex.native.tools.migrations.execution import (MigrationExecutor,
+    REVIEW_POLICY_OPTIONS, SAVE_POLICY_OPTIONS)
 
 EXTENSIONS = ['html', 'txt', 'py']
 
@@ -60,7 +57,8 @@ def pretty_options(options_dict):
 
 
 class Command(BaseCommand):
-    """Migrates files using the Django i18n syntax to Transifex Native syntax."""
+    """Migrates files using the Django i18n syntax to Transifex Native syntax.
+    """
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -68,15 +66,9 @@ class Command(BaseCommand):
             help='The domain of the message files (default: "django").',
         )
         parser.add_argument(
-            '--extension', '-e', dest='extensions', action='append',
-            help='The file extension(s) to examine (default: "html,txt,py", or "js" '
-                 'if the domain is "djangojs"). Separate multiple extensions with '
-                 'commas, or use -e multiple times.',
-        )
-        parser.add_argument(
             '--file', '-f', dest='files', action='append',
-            help='The relative paths of the files to migrate. Separate multiple paths '
-                 'with commas, or use -f multiple times.',
+            help='The relative paths of the files to migrate. Separate '
+                 'multiple paths with commas, or use -f multiple times.',
         )
         parser.add_argument(
             '--path', '-p', dest='path',
@@ -104,18 +96,14 @@ class Command(BaseCommand):
 
         options['files'] = set(options['files'] or [])
         self.files = options['files']
-
-        self.save_policy = self._create_save_policy(options['save_policy'])
-        self.review_policy = self._create_review_policy(
-            options['review_policy'])
-
         self.extensions = handle_extensions(EXTENSIONS)
-        self.stats = {
-            'processed_files': 0, 'migrations': [], 'saved': [], 'errors': [],
-        }
+
+        self.executor = MigrationExecutor(
+            options, file_migrator_func=self._migrate_file,
+        )
 
         # Show an intro message
-        _show_intro(options)
+        self.executor.show_intro()
 
         # If specific files are defined, use those
         if self.files:
@@ -128,154 +116,11 @@ class Command(BaseCommand):
         else:
             files = self._find_files(self.path)
 
-        # Ask the user for permission to continue
-        _prompt_to_start(len(files), options)
+        # Create a reusable migrator for templates code
+        self.django_migration_builder = DjangoTagMigrationBuilder()
 
         # Execute the migration
-        self.django_migration_builder = DjangoTagMigrationBuilder()
-        self.migrate_files(files)
-
-    def migrate_files(self, files):
-        """Search all related files, detect Django i18n translate hooks and migrate
-        them to Transifex syntax.
-
-        :param list files: a list of TranslatableFile objects
-        """
-        files_total = len(files)
-
-        accept_remaining_files = False
-        exit_migration = False
-
-        # Loop through each file, migrate, ask for user review if applicable,
-        # save to disk if applicable
-        for file_cnt, translatable_file in enumerate(files):
-            if exit_migration:
-                break
-
-            _, extension = os.path.splitext(translatable_file.file)
-            comment_format = '# {}\n' if extension == '.py' else '<!-- {} -->\n'
-            self.review_policy.set_comment_format(comment_format)
-
-            Color.echo(
-                '\n---- '
-                '[[high]{cnt}[end]/[high]{total}[end]] '
-                'Migrating [file]{path}[end]...'.format(
-                    path=translatable_file.path,
-                    cnt=file_cnt + 1,
-                    total=files_total,
-                )
-            )
-            self.stats['processed_files'] += 1
-            file_migration = self._migrate_file(translatable_file)
-            if not file_migration:
-                continue
-
-            modified_strings = file_migration.modified_strings
-            total_modified = len(modified_strings)
-            total_low_confidence = len(
-                [x for x in modified_strings if x.confidence == Confidence.LOW]
-            )
-            msg = pluralized(
-                '[warn]1[end] [prompt]string was modified[end]',
-                '[warn]{cnt}[end] [prompt]strings were modified[end]',
-                total_modified,
-            )
-            Color.echo(
-                '{msg}{confidence}'.format(
-                    msg=msg,
-                    confidence=(
-                        ' ([warn]{low}[end] with low confidence)'.format(
-                            low=total_low_confidence,
-                        )
-                        if total_low_confidence else ''
-                    )
-                )
-            )
-            if not total_modified:
-                continue
-
-            # If the review policy says so, prompt the user for each string
-            # If this returns True, it doesn't necessarily mean that the user
-            # will be prompted, as the actual review policy may use
-            # additional filters, e.g. only prompt for strings with low
-            # confidence
-            if self.review_policy.should_review_strings():
-                reject_remaining_strings = False
-                for string_index in range(total_modified):
-                    string_migration = modified_strings[string_index]
-
-                    # The rest of the string test_migrations should be reverted
-                    # based on the user's choice
-                    if reject_remaining_strings:
-                        string_migration.revert()
-
-                    # Optionally prompt the user to review the migration
-                    else:
-                        # Give the user the option to review
-                        # May modify `string_migration` in place
-                        result = self.review_policy.review_string(
-                            string_migration, string_index, total_modified
-                        )
-                        # The user has chosen to accept the changes
-                        # in all remaining strings. Break so that
-                        # there will be no more prompts for the rest
-                        # of the strings
-                        if result == REVIEW_ACCEPT_ALL:
-                            break
-
-                        # The user has chosen to reject the changes in all
-                        # remaining strings. Set the flag to True, so that
-                        # it will revert all changes for the rest strings
-                        # in the loop
-                        elif result == REVIEW_REJECT_ALL:
-                            reject_remaining_strings = True
-
-                        # The user has chosen to exit the migration completely
-                        # Break to exit the outer (file) loop
-                        elif result == REVIEW_EXIT:
-                            exit_migration = True
-                            break
-
-            # If the review policy says so, prompt the user for each file
-            if accept_remaining_files is False and exit_migration is False:
-                result = self.review_policy.review_file(file_migration)
-
-                # The user has chosen to reject all remaining files
-                # Break, so that we exit the outer (file) loop
-                if result == REVIEW_REJECT_ALL:
-                    break
-
-                # The user has chosen to accept all remaining files
-                # Set the flag, so that the file review policy won't be used
-                # for the remaining file test_migrations
-                elif result == REVIEW_ACCEPT_ALL:
-                    accept_remaining_files = True
-
-                # The user has chosen to exit the migration completely
-                elif result == REVIEW_EXIT:
-                    exit_migration = True
-
-            # Skip to the results
-            # Break to exit the outer (file) loop
-            if exit_migration is True:
-                break
-
-            # If the save policy says so, save the changes
-            if file_migration.modified_strings:
-                saved, error_type = self.save_policy.save_file(file_migration)
-            else:
-                saved, error_type = False, None
-
-            # Update stats
-            self.stats['migrations'].append(
-                (translatable_file.path, file_migration)
-            )
-            if saved:
-                self.stats['saved'].append(file_migration)
-            elif error_type is not None:
-                self.stats['errors'].append(file_migration)
-
-        _show_results(files, self.stats)
+        self.executor.migrate_files(files)
 
     def _migrate_file(self, translatable_file):
         """Extract source strings from the given file.
@@ -393,181 +238,3 @@ class Command(BaseCommand):
 
     def output(self, msg):
         print(msg)
-
-    def _create_save_policy(self, policy_id):
-        """Create the save policy object that corresponds to the given ID.
-
-        :param str policy_id: the ID of the policy to create, as expected
-            in the command parameters
-        :return: a SavePolicy subclass
-        :rtype: SavePolicy
-        """
-        policy_id = policy_id.lower()
-        if policy_id == NoopSavePolicy.name:
-            return NoopSavePolicy()
-        elif policy_id == NewFileSavePolicy.name:
-            return NewFileSavePolicy()
-        elif policy_id == BackupSavePolicy.name:
-            return BackupSavePolicy()
-        elif policy_id == ReplaceSavePolicy.name:
-            return ReplaceSavePolicy()
-
-        raise AttributeError('Invalid save policy ID={}'.format(policy_id))
-
-    def _create_review_policy(self, policy_id):
-        """Create the review policy object that corresponds to the given ID.
-
-        :param str policy_id: the ID of the policy to create, as expected
-            in the command parameters
-        :return: a ReviewPolicy subclass
-        :rtype: ReviewPolicy
-        """
-        if policy_id == NoopReviewPolicy.name:
-            return NoopReviewPolicy()
-        elif policy_id == FileReviewPolicy.name:
-            return FileReviewPolicy()
-        elif policy_id == StringReviewPolicy.name:
-            return StringReviewPolicy()
-        elif policy_id == LowConfidenceFileReviewPolicy.name:
-            return LowConfidenceFileReviewPolicy()
-        elif policy_id == LowConfidenceStringReviewPolicy.name:
-            return LowConfidenceStringReviewPolicy()
-
-        raise AttributeError('Invalid review policy ID={}'.format(policy_id))
-
-
-def _show_intro(options):
-    """Show an introductory message to help the user understand what is going on.
-
-    :param dict options: the configuration options of the command
-    """
-    Color.echo(
-        '[high]'
-        '\n####################################################################\n'
-        'Running migration from Django i18n syntax to Transifex Native syntax\n'
-        '[end]'
-        '\nThis migration is idempotent, so its output should not change if run'
-        '\nmultiple times with the same configuration.'
-    )
-    Color.echo('\n[high]Configuration:[end]')
-    if options['path']:
-        Color.echo('[opt]Path:[end] [file]{}[end]'.format(options['path']))
-    if options['files']:
-        Color.echo('[opt]Files:[end]')
-        Color.echo(
-            '\n'.join([
-                ' - [file]{}[end]'.format(x)
-                for x in options['files']
-            ])
-        )
-    Color.echo(
-        '[opt]Review policy:[end] [high]{}[end] -> {}'.format(
-            options['review_policy'],
-            REVIEW_POLICY_OPTIONS[options['review_policy']],
-        ).strip()
-    )
-    Color.echo(
-        '[opt]Save policy:[end] [high]{}[end] -> {}'.format(
-            options['save_policy'],
-            SAVE_POLICY_OPTIONS[options['save_policy']],
-        ).strip()
-    )
-
-
-def _prompt_to_start(total_files, options):
-    """Prompt the user before starting the migration.
-
-    If the user chooses to not go through with it, sys.exit() is called.
-
-    :param int total_files: the total number of files to migrate
-    :param dict options: the configuration options of the command
-    """
-    msg = pluralized(
-        'Found [warn]{cnt}[end] file to check for translatable strings.',
-        'Found [warn]{cnt}[end] files to check for translatable strings.',
-        total_files,
-    )
-    Color.echo('\n{}'.format(msg))
-
-    if not total_files:
-        Color.echo('\n[high]Migration ended.[end]')
-        sys.exit(1)
-
-    if (
-        options['save_policy'] != NoopSavePolicy.name
-        and options['review_policy'] == NoopReviewPolicy.name
-    ):
-        Color.echo(
-            '\n[warn]WARNING! The selected configuration will save all files'
-            ' automatically, without allowing you to do any reviewing first'
-            '.[end]'
-        )
-
-    while True:
-        reply = prompt(
-            Color.format(
-                '[opt](Y)[end] Yes [opt](N)[end] No'
-            ),
-            description='Are you sure you want to continue?',
-            default='N',
-        )
-        reply = reply.upper()
-        if reply == 'Y':
-            return
-        elif reply == 'N':
-            Color.echo('\n[high]Migration aborted.[end]')
-            sys.exit(1)
-
-
-def _show_results(files, stats):
-    """Show a detailed report of how the migration went.
-
-    :param list files: a list of TranslatableFile objects
-    :param dict stats: a dictionary with all statistics of the execution
-    """
-    Color.echo('\n\n[high]Migration completed![end]')
-    Color.echo('--------------------')
-    Color.echo('[high]Files found:[end] [warn]{}[end]'.format(
-        len(files))
-    )
-    Color.echo('[high]Files processed:[end] [warn]{}[end]'.format(
-        stats['processed_files'])
-    )
-
-    files_modified = 0
-    strings_modified = 0
-    for _, file_migration in stats['migrations']:
-        new_string_count = len(file_migration.modified_strings)
-        strings_modified += new_string_count
-        if new_string_count:
-            files_modified += 1
-    Color.echo(
-        '[high]File migrations created:[end] [warn]{}[end]'.format(
-            files_modified
-        )
-    )
-    Color.echo(
-        '[high]String migration inside these files: [warn]{}[end]'.format(
-            strings_modified
-        )
-    )
-    Color.echo('[high]Files saved:[end] [warn]{}[end]'.format(
-        len(stats['saved'])
-    ))
-    saved_str = '\n'.join([
-        ' - [file]{}[end]'.format(x.filename)
-        for x in stats['saved']
-    ])
-    if saved_str:
-        Color.echo(saved_str)
-    Color.echo('[high]Errors found:[end] [warn]{}[end]'.format(
-        len(stats['errors'])
-    ))
-    errors_str = '\n'.join([
-        ' - [warn]{}[end]'.format(x.filename)
-        for x in stats['errors']
-    ])
-    if errors_str:
-        Color.echo(errors_str)
-
-    Color.echo('')

--- a/transifex/native/tools/migrations/execution.py
+++ b/transifex/native/tools/migrations/execution.py
@@ -1,0 +1,404 @@
+import os
+import sys
+
+from transifex.common.console import Color, pluralized, prompt
+from transifex.native.tools.migrations.models import Confidence
+from transifex.native.tools.migrations.review import NoopReviewPolicy, FileReviewPolicy, \
+    StringReviewPolicy, LowConfidenceFileReviewPolicy, LowConfidenceStringReviewPolicy, \
+    REVIEW_ACCEPT_ALL, REVIEW_REJECT_ALL, REVIEW_EXIT
+from transifex.native.tools.migrations.save import NoopSavePolicy, NewFileSavePolicy, \
+    BackupSavePolicy, ReplaceSavePolicy
+
+
+SAVE_POLICY_OPTIONS = {
+    NoopSavePolicy.name: 'no changes will be saved\n',
+    NewFileSavePolicy.name: 'migrated content will be saved in a new file, '
+                            'named <filename>__native.<extension>\n',
+    BackupSavePolicy.name: 'migrated content will be saved directly in the '
+                           'original file path, and a backup will also be '
+                           'saved in <filename>.<extension>.bak\n',
+    ReplaceSavePolicy: 'migrated content will be saved in the original file',
+}
+
+REVIEW_POLICY_OPTIONS = {
+    NoopReviewPolicy.name: 'everything will be done automatically without '
+                           'having a chance to review anything\n',
+    FileReviewPolicy.name: 'you get a chance to review each migrated file '
+                           'before it is saved\n',
+    StringReviewPolicy.name: 'you get a chance to review each string of each '
+                             'file before the file is saved\n',
+    LowConfidenceFileReviewPolicy.name: 'you get a chance to review each '
+                                        'migrated file that includes at least '
+                                        'one string that has a low migration '
+                                        'confidence\n',
+    LowConfidenceStringReviewPolicy.name: 'you get a chance to review each '
+                                          'string that has a low migration '
+                                          'confidence\n',
+}
+
+
+class MigrationExecutor(object):
+    """Responsible for orchestrating a migration of multiple files
+    to Transifex Native syntax.
+
+
+    It guides the user throughout the process, providing important
+    feedback in the console. It supports various "review" and "save"
+    policies, that determine what the user is asked to accept or reject
+    before being saved, and the file location the changes are saved in.
+
+    It is agnostic to any specific Python framework. The part that
+    does the actual transformation from a specific framework (e.g. Django)
+    to Transifex Native is handled by the `file_migrator_func` callable
+    that is provided externally through dependency injection.
+    """
+
+    def __init__(self, options, file_migrator_func):
+        """Constructor.
+
+        :param dict options: the following configuration options of
+            the migration:
+             - 'files': a list of files to migrate, relative to
+                current location
+             - 'review_policy' (see REVIEW_POLICY_OPTIONS)
+             - 'save_policy' (SAVE_POLICY_OPTIONS)
+        :param func file_migrator_func: a function that is responsible for
+            getting a TranslatableFile object and returning a FileMigration
+            object
+        """
+        self.options = options
+        self.file_migrator_func = file_migrator_func
+        self.save_policy = _create_save_policy(options['save_policy'])
+        self.review_policy = _create_review_policy(
+            options['review_policy']
+        )
+        self.stats = {
+            'processed_files': 0, 'migrations': [], 'saved': [], 'errors': [],
+        }
+
+    def migrate_files(self, files):
+        """Search all related files, detect Django i18n translate hooks and
+        migrate them to Transifex syntax.
+
+        :param list files: a list of TranslatableFile objects
+        """
+        files_total = len(files)
+
+        # Ask the user for permission to continue
+        self._prompt_to_start(len(files))
+
+        accept_remaining_files = False
+        exit_migration = False
+
+        # Loop through each file, migrate, ask for user review if applicable,
+        # save to disk if applicable
+        for file_cnt, translatable_file in enumerate(files):
+            if exit_migration:
+                break
+
+            _, extension = os.path.splitext(translatable_file.file)
+            comment_format = (
+                '# {}\n' if extension == '.py' else '<!-- {} -->\n'
+            )
+            self.review_policy.set_comment_format(comment_format)
+
+            Color.echo(
+                '\n---- '
+                '[[high]{cnt}[end]/[high]{total}[end]] '
+                'Migrating [file]{path}[end]...'.format(
+                    path=translatable_file.path,
+                    cnt=file_cnt + 1,
+                    total=files_total,
+                )
+            )
+            self.stats['processed_files'] += 1
+            file_migration = self.file_migrator_func(translatable_file)
+            if not file_migration:
+                continue
+
+            modified_strings = file_migration.modified_strings
+            total_modified = len(modified_strings)
+            total_low_confidence = len(
+                [x for x in modified_strings if x.confidence == Confidence.LOW]
+            )
+            msg = pluralized(
+                '[warn]1[end] [prompt]string was modified[end]',
+                '[warn]{cnt}[end] [prompt]strings were modified[end]',
+                total_modified,
+            )
+            Color.echo(
+                '{msg}{confidence}'.format(
+                    msg=msg,
+                    confidence=(
+                        ' ([warn]{low}[end] with low confidence)'.format(
+                            low=total_low_confidence,
+                        )
+                        if total_low_confidence else ''
+                    )
+                )
+            )
+            if not total_modified:
+                continue
+
+            # If the review policy says so, prompt the user for each string
+            # If this returns True, it doesn't necessarily mean that the user
+            # will be prompted, as the actual review policy may use
+            # additional filters, e.g. only prompt for strings with low
+            # confidence
+            if self.review_policy.should_review_strings():
+                reject_remaining_strings = False
+                for string_index in range(total_modified):
+                    string_migration = modified_strings[string_index]
+
+                    # The rest of the string test_migrations should be reverted
+                    # based on the user's choice
+                    if reject_remaining_strings:
+                        string_migration.revert()
+
+                    # Optionally prompt the user to review the migration
+                    else:
+                        # Give the user the option to review
+                        # May modify `string_migration` in place
+                        result = self.review_policy.review_string(
+                            string_migration, string_index, total_modified
+                        )
+                        # The user has chosen to accept the changes
+                        # in all remaining strings. Break so that
+                        # there will be no more prompts for the rest
+                        # of the strings
+                        if result == REVIEW_ACCEPT_ALL:
+                            break
+
+                        # The user has chosen to reject the changes in all
+                        # remaining strings. Set the flag to True, so that
+                        # it will revert all changes for the rest strings
+                        # in the loop
+                        elif result == REVIEW_REJECT_ALL:
+                            reject_remaining_strings = True
+
+                        # The user has chosen to exit the migration completely
+                        # Break to exit the outer (file) loop
+                        elif result == REVIEW_EXIT:
+                            exit_migration = True
+                            break
+
+            # If the review policy says so, prompt the user for each file
+            if accept_remaining_files is False and exit_migration is False:
+                result = self.review_policy.review_file(file_migration)
+
+                # The user has chosen to reject all remaining files
+                # Break, so that we exit the outer (file) loop
+                if result == REVIEW_REJECT_ALL:
+                    break
+
+                # The user has chosen to accept all remaining files
+                # Set the flag, so that the file review policy won't be used
+                # for the remaining file test_migrations
+                elif result == REVIEW_ACCEPT_ALL:
+                    accept_remaining_files = True
+
+                # The user has chosen to exit the migration completely
+                elif result == REVIEW_EXIT:
+                    exit_migration = True
+
+            # Skip to the results
+            # Break to exit the outer (file) loop
+            if exit_migration is True:
+                break
+
+            # If the save policy says so, save the changes
+            if file_migration.modified_strings:
+                saved, error_type = self.save_policy.save_file(file_migration)
+            else:
+                saved, error_type = False, None
+
+            # Update stats
+            self.stats['migrations'].append(
+                (translatable_file.path, file_migration)
+            )
+            if saved:
+                self.stats['saved'].append(file_migration)
+            elif error_type is not None:
+                self.stats['errors'].append(file_migration)
+
+        self._show_results(files, self.stats)
+
+    def show_intro(self):
+        """Show an introductory message to help the user understand what
+        is going on.
+        """
+        Color.echo(
+            '[high]'
+            '\n############################################################'
+            '########\n'
+            'Running migration from Django i18n syntax to Transifex Native '
+            'syntax\n'
+            '[end]'
+            '\nThis migration is idempotent, so its output should not '
+            'change if run'
+            '\nmultiple times with the same configuration.'
+        )
+        Color.echo('\n[high]Configuration:[end]')
+        if self.options['path']:
+            Color.echo(
+                '[opt]Path:[end] [file]{}[end]'.format(self.options['path'])
+            )
+        if self.options['files']:
+            Color.echo('[opt]Files:[end]')
+            Color.echo(
+                '\n'.join([
+                    ' - [file]{}[end]'.format(x)
+                    for x in self.options['files']
+                ])
+            )
+        Color.echo(
+            '[opt]Review policy:[end] [high]{}[end] -> {}'.format(
+                self.options['review_policy'],
+                REVIEW_POLICY_OPTIONS[self.options['review_policy']],
+            ).strip()
+        )
+        Color.echo(
+            '[opt]Save policy:[end] [high]{}[end] -> {}'.format(
+                self.options['save_policy'],
+                SAVE_POLICY_OPTIONS[self.options['save_policy']],
+            ).strip()
+        )
+
+    def _prompt_to_start(self, total_files):
+        """Prompt the user before starting the migration.
+
+        If the user chooses to not go through with it, sys.exit() is called.
+
+        :param int total_files: the total number of files to migrate
+        """
+        msg = pluralized(
+            'Found [warn]{cnt}[end] file to check for translatable strings.',
+            'Found [warn]{cnt}[end] files to check for translatable strings.',
+            total_files,
+        )
+        Color.echo('\n{}'.format(msg))
+
+        if not total_files:
+            Color.echo('\n[high]Migration ended.[end]')
+            sys.exit(1)
+
+        if (
+            self.options['save_policy'] != NoopSavePolicy.name
+            and self.options['review_policy'] == NoopReviewPolicy.name
+        ):
+            Color.echo(
+                '\n[warn]WARNING! The selected configuration will save '
+                'all files automatically, without allowing you to do any '
+                'reviewing first.[end]'
+            )
+
+        while True:
+            reply = prompt(
+                Color.format(
+                    '[opt](Y)[end] Yes [opt](N)[end] No'
+                ),
+                description='Are you sure you want to continue?',
+                default='N',
+            )
+            reply = reply.upper()
+            if reply == 'Y':
+                return
+            elif reply == 'N':
+                Color.echo('\n[high]Migration aborted.[end]')
+                sys.exit(1)
+
+    def _show_results(self, files, stats):
+        """Show a detailed report of how the migration went.
+
+        :param list files: a list of TranslatableFile objects
+        :param dict stats: a dictionary with all statistics of the execution
+        """
+        Color.echo('\n\n[high]Migration completed![end]')
+        Color.echo('--------------------')
+        Color.echo('[high]Files found:[end] [warn]{}[end]'.format(
+            len(files))
+        )
+        Color.echo('[high]Files processed:[end] [warn]{}[end]'.format(
+            stats['processed_files'])
+        )
+
+        files_modified = 0
+        strings_modified = 0
+        for _, file_migration in stats['migrations']:
+            new_string_count = len(file_migration.modified_strings)
+            strings_modified += new_string_count
+            if new_string_count:
+                files_modified += 1
+        Color.echo(
+            '[high]File migrations created:[end] [warn]{}[end]'.format(
+                files_modified
+            )
+        )
+        Color.echo(
+            '[high]String migrations inside these files: [warn]{}[end]'.format(
+                strings_modified
+            )
+        )
+        Color.echo('[high]Files saved:[end] [warn]{}[end]'.format(
+            len(stats['saved'])
+        ))
+        saved_str = '\n'.join([
+            ' - [file]{}[end]'.format(x.filename)
+            for x in stats['saved']
+        ])
+        if saved_str:
+            Color.echo(saved_str)
+        Color.echo('[high]Errors found:[end] [warn]{}[end]'.format(
+            len(stats['errors'])
+        ))
+        errors_str = '\n'.join([
+            ' - [warn]{}[end]'.format(x.filename)
+            for x in stats['errors']
+        ])
+        if errors_str:
+            Color.echo(errors_str)
+
+        Color.echo('')
+
+
+def _create_save_policy(policy_id):
+    """Create the save policy object that corresponds to the given ID.
+
+    :param str policy_id: the ID of the policy to create, as expected
+        in the command parameters
+    :return: a SavePolicy subclass
+    :rtype: SavePolicy
+    """
+    policy_id = policy_id.lower()
+    if policy_id == NoopSavePolicy.name:
+        return NoopSavePolicy()
+    elif policy_id == NewFileSavePolicy.name:
+        return NewFileSavePolicy()
+    elif policy_id == BackupSavePolicy.name:
+        return BackupSavePolicy()
+    elif policy_id == ReplaceSavePolicy.name:
+        return ReplaceSavePolicy()
+
+    raise AttributeError('Invalid save policy ID={}'.format(policy_id))
+
+
+def _create_review_policy(policy_id):
+    """Create the review policy object that corresponds to the given ID.
+
+    :param str policy_id: the ID of the policy to create, as expected
+        in the command parameters
+    :return: a ReviewPolicy subclass
+    :rtype: ReviewPolicy
+    """
+    if policy_id == NoopReviewPolicy.name:
+        return NoopReviewPolicy()
+    elif policy_id == FileReviewPolicy.name:
+        return FileReviewPolicy()
+    elif policy_id == StringReviewPolicy.name:
+        return StringReviewPolicy()
+    elif policy_id == LowConfidenceFileReviewPolicy.name:
+        return LowConfidenceFileReviewPolicy()
+    elif policy_id == LowConfidenceStringReviewPolicy.name:
+        return LowConfidenceStringReviewPolicy()
+
+    raise AttributeError('Invalid review policy ID={}'.format(policy_id))

--- a/transifex/native/tools/migrations/mark.py
+++ b/transifex/native/tools/migrations/mark.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""This module contains everything related to the functionality
+that marks a migration to Transifex Native code for proofreading.
+
+When a file or a string in a file is marked for proofreading, a special
+string is added in the file, so that users can grep for it and
+make sure the migration is correct.
+"""
+
+from __future__ import unicode_literals
+
+from transifex.common.console import Color
+from transifex.native.tools.migrations.models import Confidence
+
+MARK_PROOFREAD_STRING = 'Transifex Native: PROOFREAD_STRING'
+MARK_PROOFREAD_FILE = 'Transifex Native: PROOFREAD_FILE'
+
+
+def mark_string(string_migration, comment_format, mark):
+    """Mark a string migration for proofreading.
+
+    Adds a comment in the beginning of this string.
+
+    :param StringMigration string_migration: the string migration object
+        to update
+    :param unicode comment_format: the format of the comment,
+        compatible with the file type of the migration
+    :param str mark: the string to add as a comment
+    """
+    string_migration.update(
+        '', comment_format.format(mark),
+        append=False,
+    )
+
+
+class MarkPolicy(object):
+    """Determines if a migrated file or a migrated string will be marked
+    for proofread.
+    """
+    name = None
+
+    def __init__(self):
+        # This determines how review comments will appear
+        # inside the migrated file. It is dynamic because different files
+        # support different comment formats, e.g.
+        # - '# Comment' in Python
+        # - '<!-- Comment -->' in HTML
+        self._comment_format = '{}'
+
+    def set_comment_format(self, comment_format):
+        """Define the comment format to use when a policy adds
+        comments to the migrated file.
+
+        Example:
+        >>> set_comment_format('# {}')
+
+        :param unicode comment_format: the format to use; must include '{}'
+        :raise ValueError: if `comment_format` does not include '{}'
+        """
+        if '{}' not in comment_format:
+            raise ValueError('The provided `comment_format` must include {}')
+        self._comment_format = comment_format
+
+    def should_mark_strings(self):
+        """Returns whether or not a policy object wants to mark individual
+        strings.
+
+        Although policy subclasses can only mark *some* strings, and not all,
+        this method is important for optimization, so that the objects that
+        use a policy object know if they need to feed each string migration
+        to the mark policy or not.
+        """
+        return False
+
+    def mark_file(self, file_migration):
+        """The base class does nothing.
+
+        :param FileMigration file_migration: the migration object
+        :return: True if the file was marked, False otherwise
+        :rtype: bool
+        """
+        return False
+
+    def mark_string(self, string_migration):
+        """The base class does nothing.
+
+        :param StringMigration string_migration: the migration object
+        :return: True if the string was marked, False otherwise
+        :rtype: bool
+        """
+        return False
+
+
+class NoopMarkPolicy(MarkPolicy):
+    """Does not mark anything."""
+
+    name = 'none'
+
+
+class MarkLowConfidenceFilesPolicy(MarkPolicy):
+    """Marks all files that have at least one string with low confidence."""
+
+    name = 'file-low'
+
+    def mark_file(self, file_migration):
+        if not file_migration.low_confidence_strings:
+            return False
+
+        first_string_migration = file_migration.strings[0]
+        if MARK_PROOFREAD_FILE in first_string_migration.new:
+            return False
+
+        mark_string(
+            first_string_migration,
+            self._comment_format,
+            MARK_PROOFREAD_FILE,
+        )
+        Color.echo('📝 File automatically marked for proofreading')
+        return True
+
+
+class MarkLowConfidenceStringsPolicy(MarkPolicy):
+    """Marks all string that have low confidence."""
+
+    name = 'string-low'
+
+    def should_mark_strings(self):
+        return True
+
+    def mark_string(self, string_migration):
+        if string_migration.confidence != Confidence.LOW:
+            return False
+
+        if MARK_PROOFREAD_STRING in string_migration.new:
+            return False
+
+        mark_string(
+            string_migration,
+            self._comment_format,
+            MARK_PROOFREAD_STRING,
+        )
+        return True
+
+
+def create_mark_policy(policy_id):
+    """Create the mark policy object that corresponds to the given ID.
+
+    :param str policy_id: the ID of the policy to create, as defined
+        in the MarkPolicy subclasses
+    :return: an instance of a subclass of MarkPolicy
+    :rtype: MarkPolicy
+    """
+    policy_classes = {
+        x.name: x
+        for x in [
+            NoopMarkPolicy, MarkLowConfidenceFilesPolicy,
+            MarkLowConfidenceStringsPolicy,
+        ]
+    }
+    try:
+        _class = policy_classes[policy_id.lower()]
+        return _class()
+    except KeyError:
+        raise AttributeError('Invalid mark policy ID={}'.format(policy_id))

--- a/transifex/native/tools/migrations/models.py
+++ b/transifex/native/tools/migrations/models.py
@@ -2,6 +2,11 @@ from __future__ import unicode_literals
 
 
 class Confidence(object):
+    """The level of certainty for a particular migration.
+
+    If a migration of a string from a certain framework to Transifex Native
+    is very complex, or an edge-case, it can be marked as low-confidence.
+    """
 
     LOW = 1
     HIGH = 2
@@ -28,9 +33,9 @@ class StringMigration(object):
     def __init__(self, original, new, confidence=Confidence.HIGH):
         """Constructor.
 
-        :param unicode original:
-        :param unicode new:
-        :param int confidence:
+        :param unicode original: the original string in 3rd-party syntax
+        :param unicode new: the new string in Transifex Native syntax
+        :param int confidence: the level of confidence of this migration
         """
         self.original = ''
         self.new = ''
@@ -39,11 +44,25 @@ class StringMigration(object):
         self.update(original, new)
 
     def update(self, extra_original, extra_new, confidence=None, append=True):
-        """Append a extra_new substring.
+        """Update the string migration, adding a new part in the original
+        string and a new part in the new string.
 
-        :param unicode extra_original:
-        :param unicode extra_new:
-        :param int confidence:
+        Usage:
+        >>> migration = StringMigration('a', 'b')
+        >>> # 'a' -> 'b'
+        >>> migration.update('c', 'C')
+        >>> # 'ac' -> 'bC'
+        >>> migration.update('>', '>>', append=False)
+        >>> # '>ac' -> '>>bC'
+        >>> migration.update('', '<<', append=True)
+        >>> # '>ac' -> '>>bC<<'
+
+        :param unicode extra_original: the additional string to add
+            to the original string
+        :param unicode extra_new: the additional string to add
+            to the new string
+        :param int confidence: the new level of confidence of the migration;
+            if `None` is provided, the previous confidence is preserved
         :param bool append: if True, the changes will be appended to the end
             of the strings, otherwise they will be prepended in the beginning
         """

--- a/transifex/native/tools/migrations/models.py
+++ b/transifex/native/tools/migrations/models.py
@@ -141,9 +141,21 @@ class FileMigration(object):
 
     @property
     def modified_strings(self):
-        """A list of all StringMigration objects with content that was really migrated,
-        for a particular file.
+        """A list of all StringMigration objects with content that was really
+        migrated, for a particular file.
 
         :rtype: List[StringMigration]
         """
         return [string for string in self.strings if string.modified]
+
+    @property
+    def low_confidence_strings(self):
+        """A list of all StringMigration objects with migrated content
+        that has low confidence, for a particular file.
+
+        :rtype: List[StringMigration]
+        """
+        return [
+            x for x in self.modified_strings
+            if x.confidence == Confidence.LOW
+        ]

--- a/transifex/native/tools/migrations/save.py
+++ b/transifex/native/tools/migrations/save.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
+"""This module contains everything related to the saving functionality
+of a migration from another i18n framework to Transifex Native.
 
+The classes defined here are responsible for saving the migrated content
+to the proper target, saving a backup and so on.
+"""
 from __future__ import unicode_literals
 
 import os
@@ -66,7 +71,7 @@ class SavePolicy(object):
             with open(path, "w") as f:
                 f.write(content_func())
                 Color.echo(
-                    '✅️ {} saved at [file]{}[end]'.format(file_type, path)
+                    '💾️ {} file saved at [file]{}[end]'.format(file_type, path)
                 )
                 return True, None
         except IOError as e:
@@ -90,17 +95,17 @@ class SavePolicy(object):
 class NoopSavePolicy(SavePolicy):
     """Doesn't save anything to a file, i.e. a dry-run."""
 
+    name = 'none'
+
     def save_file(self, file_migration):
-        Color.echo(
-            'Dry-run: no file was saved (file={})'.format(
-                file_migration.filename
-            )
-        )
+        Color.echo('Dry-run: no file was saved')
         return False, None
 
 
 class NewFileSavePolicy(SavePolicy):
     """Saves the contents to a new file."""
+
+    name = 'new'
 
     def save_file(self, file_migration):
         """Save the new content in a new file.
@@ -116,6 +121,8 @@ class NewFileSavePolicy(SavePolicy):
 
 class BackupSavePolicy(SavePolicy):
     """Saves the contents to the original file, but takes a backup first."""
+
+    name = 'backup'
 
     def save_file(self, file_migration):
         """Save the new content in the original path, but take a backup first.
@@ -146,8 +153,10 @@ class BackupSavePolicy(SavePolicy):
         )
 
 
-class InPlaceSavePolicy(SavePolicy):
+class ReplaceSavePolicy(SavePolicy):
     """Saves the contents to the original file, without taking any backup."""
+
+    name = 'replace'
 
     def save_file(self, file_migration):
         """Save the new content in the original path.

--- a/transifex/native/tools/migrations/save.py
+++ b/transifex/native/tools/migrations/save.py
@@ -34,6 +34,8 @@ class SavePolicy(object):
     # Replace the original file with no backup
     IN_PLACE = 3
 
+    name = None
+
     def save_file(self, file_migration):
         """Called when a file migration is ready to be saved.
 
@@ -54,8 +56,8 @@ class SavePolicy(object):
         during the generation of the content.
 
         Usage:
-        >>> _safe_save('file/path.html', lambda: content, file_type='Backup')
-        >>> _safe_save('file/path.html', my_provider.get_content, file_type='Backup')
+        >>> _safe_save('file/path.html', lambda: content, file_type='Backup')  # noqa
+        >>> _safe_save('file/path.html', my_provider.get_content, file_type='Backup')  # noqa
 
         :param basestring path: the path to save to
         :param callable content_func: a callable that should return the content
@@ -168,3 +170,25 @@ class ReplaceSavePolicy(SavePolicy):
             file_migration.compile,
             file_type='Original',
         )
+
+
+def create_save_policy(policy_id):
+    """Create the save policy object that corresponds to the given ID.
+
+    :param str policy_id: the ID of the policy to create, as expected
+        in the command parameters
+    :return: a SavePolicy subclass
+    :rtype: SavePolicy
+    """
+    policy_classes = {
+        x.name: x
+        for x in [
+            NoopSavePolicy, NewFileSavePolicy, BackupSavePolicy,
+            ReplaceSavePolicy,
+        ]
+    }
+    try:
+        _class = policy_classes[policy_id.lower()]
+        return _class()
+    except KeyError:
+        raise AttributeError('Invalid save policy ID={}'.format(policy_id))


### PR DESCRIPTION
This PR introduces the following changes:

- Improve messaging and color formatting
- Add option to exit migration at any time
- Add convenience method for pluralized strings in console output
- Add & improve docstrings
- Abstract migration logic away from Django module
- Add option to mark strings & files for proofread

## Add option to mark strings & files for proofread
Users can decided if any automatic marking is done for low-confidence strings when the `migratetransifex` command is executed.

### Mark on string level
```
# This command will prepend a comment before each modified string that has low confidence, i.e. that is a bit too complex for the migration to be 100% sure that it has been converted properly to Transifex Native syntax.
./manage.py migratetransifex  --review=none --mark=string-low --save=replace --path templates/
```

Users can grep for `Transifex Native: PROOFREAD_STRING` inside their files, and manually proofread these conversions.

### Mark on file level
```
# This command will prepend a comment in the beginning of every modified file that has at least 1 string with low confidence.
./manage.py migratetransifex  --review=none --mark=file-low --save=replace --path templates/
```

Users can grep for `Transifex Native: PROOFREAD_FILE` inside their files, and manually proofread these conversions.

