### PR TITLE
Better support plurals

### DIFF
--- a/tests/common/test_is_plural.py
+++ b/tests/common/test_is_plural.py
@@ -1,0 +1,24 @@
+from transifex.common.utils import is_plural
+
+
+def test_simple():
+    assert not is_plural("hello world")
+    assert is_plural("{cnt, plural, one {ONE} other {OTHER}}")
+    assert is_plural("{cnt, plural, one {ONE} =5 {OTHER}}")
+    assert is_plural("{cnt, plural, =1 {ONE} other {OTHER}}")
+    assert is_plural("{cnt, plural, =1 {ONE} =5 {OTHER}}")
+
+
+def test_almost_plural():
+    assert not is_plural("{cnt, plural, one {ONE} other {OTHER}")
+    assert not is_plural("{cnt, plurall, one {ONE} other {OTHER}}")
+    assert not is_plural("{cnt, plural, onee {ONE} other {OTHER}}")
+    assert not is_plural("{cnt, plural, =7 {ONE} other {OTHER}}")
+    assert not is_plural("{cnt, plural, one {ONE}, other {OTHER}}")
+    assert not is_plural("{cnt, plural, one {ONE} many {OTHER}}")
+    assert not is_plural("{cnt, plural, one {ONE}}")
+
+
+def test_escapes():
+    assert is_plural("{cnt, plural, one {O '' NE} other {OTHER}}")
+    assert is_plural("{cnt, plural, one {O '{ NE'} other {OTHER}}")

--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -224,3 +224,16 @@ class TestNative(object):
         mytx.fetch_translations()
         assert mock_cds.call_count == 1
         assert mock_cache.call_count > 0
+
+    @patch('transifex.native.core.MemoryCache.get')
+    def test_plural(self, cache_mock):
+        cache_mock.return_value = u'{???, plural, one {ONE} other {OTHER}}'
+        tx = self._get_tx()
+        translation = tx.translate(u'{cnt, plural, one {one} other {other}}',
+                                   u"fr_FR",
+                                   params={'cnt': 1})
+        assert translation == u'ONE'
+        translation = tx.translate(u'{cnt, plural, one {one} other {other}}',
+                                   u"fr_FR",
+                                   params={'cnt': 2})
+        assert translation == u'OTHER'

--- a/transifex/common/utils.py
+++ b/transifex/common/utils.py
@@ -1,4 +1,5 @@
 import importlib
+import re
 from datetime import datetime
 from hashlib import md5
 
@@ -68,3 +69,119 @@ def make_hashable(data):
         )
     else:
         return data
+
+
+def is_plural(string):
+    """ Determine if `string` is the simplest possible version of a pluralized
+        ICU string, ie whether the plural syntax is on the outermost part of
+        the string.
+
+        So, this `{cnt, plural, one {ONE} other {OTHER}}` will return True, but
+        this `hello {cnt, plural, one {ONE} other {OTHER}}` will return False.
+    """
+
+    try:
+        # {cnt, plural, one {foo} other {foos}}
+        # ^^^^^^^^^^^^
+        variable_name, remaining = _consume_preamble(string)
+        plurals = {}
+        # {cnt, plural, one {foo} other {foos}}
+        #               ^^^^^^^^^
+        rule, remaining = _consume_rule(remaining)
+        plural, remaining = _consume_plural(remaining.strip())
+        plurals[rule] = plural
+        while remaining.strip():
+            # {cnt, plural, one {foo} other {foos}}
+            #                         ^^^^^^^^^^^^
+            rule, remaining = _consume_rule(remaining.strip())
+            plural, remaining = _consume_plural(remaining.strip())
+            plurals[rule] = plural
+    except Exception:
+        return False
+
+    if ((len(plurals) == 1 and 'other' not in plurals) or
+            bool({'one', 'other'} - set(plurals.keys()))):
+        return False
+
+    return True
+
+
+# The `_consume_FOO` functions take an input, "consume" a part of it to produce
+# the first return value and return the "unconsumed" part of the input as the
+# second return value
+def _consume_preamble(string):
+    """ Usage:
+
+            >>> _consume_preamble('{cnt, plural, one {ONE} other {OTHER}}')
+            <<< ('cnt', 'one {ONE} other {OTHER}')
+    """
+
+    if string[0] != '{' or string[-1] != '}':
+        raise ValueError()
+    first_comma_pos = string.index(',')
+    second_comma_pos = string.index(',', first_comma_pos + 1)
+    variable_name = string[1:first_comma_pos].strip()
+    keyword = string[first_comma_pos + 1:second_comma_pos].strip()
+    if not re.search(r'[\w_]+', variable_name) or keyword != "plural":
+        raise ValueError()
+    return variable_name, string[second_comma_pos + 1:-1].strip()
+
+
+def _consume_rule(string):
+    """ Usage:
+
+            >>> _consume_rule('one {ONE} other {OTHER}')
+            <<< ('one', '{ONE} other {OTHER}')
+            >>> _consume_rule('other {OTHER}')
+            <<< ('other', '{OTHER}')
+    """
+
+    left_bracket_pos = string.index('{')
+    rule = string[:left_bracket_pos].strip()
+    if rule[0] == "=":
+        rule = rule[1:]
+        rule = int(rule)
+        rule = {0: "zero",
+                1: "one", 2: "two", 3: "few", 4: "many", 5: "other"}[rule]
+    else:
+        if rule not in ('zero', 'one', 'two', 'few', 'many', 'other'):
+            raise ValueError()
+    return rule, string[left_bracket_pos:].strip()
+
+
+def _consume_plural(string):
+    """ Usage:
+
+            >>> _consume_plural('{ONE} other {OTHER}')
+            <<< ('ONE', 'other {OTHER}')
+            >>> _consume_plural('{OTHER}')
+            <<< ('OTHER', '')
+    """
+
+    bracket_count, escaping = 0, False
+    ptr = 0
+    while ptr < len(string):
+        char = string[ptr]
+        if char == "'":
+            try:
+                peek = string[ptr+1]
+            except IndexError:  # pragma: no cover
+                peek = None
+            if peek == "'":
+                ptr += 1
+            else:
+                if escaping:
+                    escaping = False
+                else:
+                    if peek in ('{', '}'):
+                        escaping = True
+        elif char == '{':
+            if not escaping:
+                bracket_count += 1
+        elif char == '}':
+            if not escaping:
+                bracket_count -= 1
+            if bracket_count == 0:
+                return string[1:ptr], string[ptr + 1:].strip()
+        ptr += 1
+    raise ValueError()

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import json
 
-from transifex.common.utils import generate_key
+from transifex.common.utils import generate_key, is_plural
 from transifex.native.cache import MemoryCache
 from transifex.native.cds import CDSHandler
 from transifex.native.rendering import (SourceStringErrorPolicy,
@@ -94,6 +94,14 @@ class TxNative(object):
         else:
             key = generate_key(source_string, _context)
             translation_template = self._cache.get(key, language_code)
+            if (translation_template is not None and
+                    is_plural(source_string) and
+                    translation_template.startswith('{???')):
+                variable_name = source_string[1:source_string.index(',')].\
+                    strip()
+                translation_template = ('{' +
+                                        variable_name +
+                                        translation_template[4:])
 
         # Replace the variables in the ICU translation
         params = params or {}


### PR DESCRIPTION
If CDS tries to serve a translation of a string that is saved in
Transifex as pluralized, it will not have a way of knowing the main
variable's name. Instead it will use '???'.

So, if the source string in the native application is a compatible
pluralized string and CDS returned a pluralized translation with '???'
as its variable name, this change replaces '???' with the variable name
captured from the source string before serving the translation back to
the application.

A compatible pluralized string is one with the plural pattern defined at
the outermost layer. So for example:

    {cnt, plural, one {You have # message} other {You have # messages}}

is a compatible plrualized string, while:

    You have {cnt, plural, one {# message} other {# messages}}

is not.