### PR TITLE
Add etag while fetching translations

### DIFF
--- a/tests/native/core/test_cache.py
+++ b/tests/native/core/test_cache.py
@@ -13,22 +13,22 @@ class TestMemoryCache(object):
         cache = MemoryCache()
         cache.update(
             {
-                'en': {
+                'en': (True, {
                     'table': {
                         'string': u'A table'
                     },
                     'chair': {
                         'string': u'A chair'
                     },
-                },
-                'el': {
+                }),
+                'el': (True, {
                     'table': {
                         'string': u'Ένα τραπέζι'
                     },
                     'chair': {
                         'string': u'Μια καρέκλα'
                     },
-                },
+                }),
             },
         )
         assert cache.get('table', 'en') == u'A table'

--- a/tests/native/django/test_templatetag.py
+++ b/tests/native/django/test_templatetag.py
@@ -386,7 +386,8 @@ def test_safe_and_escape_filter_on_block_ignored():
 
 def test_escaping_is_done_on_translation():
     hello_key = generate_key('hello', None)
-    tx._cache.update({'fr': {hello_key: {'string': "<xml>bonjour</xml>"}}})
+    tx._cache.update(
+        {'fr': (True, {hello_key: {'string': "<xml>bonjour</xml>"}})})
     assert (do_test('{% t "hello" %}', lang_code="fr") ==
             '&lt;xml&gt;bonjour&lt;/xml&gt;')
 
@@ -395,8 +396,15 @@ def test_source_filter_is_applied_on_translation():
     # 'hello' => 'bonjour', 'HELLO' => 'I like pancakes'
     hello_key = generate_key('hello', None)
     HELLO_key = generate_key('HELLO', None)
-    tx._cache.update({'fr': {hello_key: {'string': "bonjour"},
-                             HELLO_key: {'string': "I like pancakes"}}})
+    tx._cache.update(
+        {'fr': (
+            True,
+            {
+                hello_key: {'string': "bonjour"},
+                HELLO_key: {'string': "I like pancakes"}
+            }
+        )})
+
     assert do_test('{% t "hello"|upper %}', lang_code="fr") == "BONJOUR"
     # If the filter was applied on the source string, we would get
     # 'I like pancakes'

--- a/transifex/native/cache.py
+++ b/transifex/native/cache.py
@@ -32,16 +32,20 @@ class AbstractCache(object):
 
         where `data` is expected to be structured like:
         {
-            'fr': {
+            'fr': (True, {
                 'key1': '...',
                 'key2': '...',
-            },
-            'de': {
+            }),
+            'de': (True, {
                 'key1': '...',
                 'key2': '...',
                 'key3': '...',
-            },
+            }),
+            'gr': (False, {}),
         }
+
+        Hint: the boolean values in the tuples above refer to whether local
+        cache should be updated or not
 
         :param dict data: the translation data
         """
@@ -60,11 +64,16 @@ class MemoryCache(AbstractCache):
         :param dict data: the data to use in the cache, formatted as
             explained in AbstractCache.update()
         """
-        for lang_code, translations in data.items():
-            self._translations_by_lang[lang_code] = {
-                'translations': translations,
-                'last_update': now()
-            }
+        for lang_code, data in data.items():
+            should_update, translations = data
+            if should_update:
+                self._translations_by_lang[lang_code] = {
+                    'translations': translations,
+                    'last_update': now()
+                }
+            else:
+                # updated existing records to be aligned
+                self._translations_by_lang[lang_code]['last_update'] = now()
 
     def get(self, key, language_code):
         retrieved_translation = None


### PR DESCRIPTION
We need to use etag policy while retrieving translations to eliminate performance issues related to duplicate fetching. 