### PR TITLE
Fix templatetag when rendering missing translations

### DIFF
--- a/transifex/native/django/templatetags/transifex.py
+++ b/transifex/native/django/templatetags/transifex.py
@@ -209,7 +209,10 @@ class TNode(Node):
         )
         if self.tag_name == "t":
             source_icu_template = escape_html(source_icu_template)
-            translation_icu_template = escape_html(translation_icu_template)
+            if translation_icu_template is not None:
+                translation_icu_template = escape_html(
+                    translation_icu_template
+                )
 
         result = tx.render_translation(translation_icu_template, params,
                                        source_icu_template, locale,


### PR DESCRIPTION
Here is the problem:

When there is an untranslated string in the production database, the
cache will eventually have an entry like `key: {string: ""}`. This gets
handled by the missing policy properly.

When, however, the string is totally unknown to the production database,
the templatetag would render "None". This was done because at some point
we call `escape_html(translation_icu_template)` on a `None` value, when
`escape_html` really wants to return a string.