### PR TITLE
Fix bug with template comments

### DIFF
--- a/tests/native/django/test_tools/test_migrations/test_templatetags.py
+++ b/tests/native/django/test_tools/test_migrations/test_templatetags.py
@@ -45,6 +45,14 @@ There are {{ counter }} {{ name }} objects.
 {% blocktrans %}
     try with <xml>xml</xml>
 {% endblocktrans %}
+
+{% comment "Optional note" %}
+    <p>Commented out text with {{ create_date|date:"c" }}</p>
+{% endcomment %}
+{# This is not related to translations #}
+{% something %}
+{% comment %}This is a non-translator comment{% endcomment %}
+{% comment %}Translators: This is an orphan translator comment{% endcomment %}
 """
 
 TRANSIFEX_TEMPLATE = """
@@ -91,6 +99,13 @@ There are {counter} {name} objects.
 {% ut %}
     try with <xml>xml</xml>
 {% endut %}
+
+{% comment "Optional note" %}
+    <p>Commented out text with {{ create_date|date:"c" }}</p>
+{% endcomment %}
+{# This is not related to translations #}
+{% something %}
+{% comment %}This is a non-translator comment{% endcomment %}
 """
 
 


### PR DESCRIPTION
Previously all non-translator comments were removed during migration. For example, this chunk in a Django template would be completely removed in the migrated file:
```django
{% comment "Optional note" %}
    <p>Commented out text with {{ create_date|date:"c" }}</p>
{% endcomment %}
{# This is not related to translations #}
```

Now we distinguish between translator and non-translator comments and keep the latter intact when migrating Django templates.

# How to test
Unit tests. Also add the following as `comments.html` in a Django project:
```django
{% extends 'base.html' %}
{% load i18n %}


{# Translators: Star Wars #}
{% trans "I am your father" %}

{% comment %}Translators: May the force be with you{% endcomment %}
{% trans "May" context "month name" %}

{% comment "Optional note" %}
    <p>Commented out text with {{ create_date|date:"c" }}</p>
{% endcomment %}

{# This is not related to translations #}
{% something %}

{% comment %}This is a non-translator comment{% endcomment %}
{% comment %}Translators: This is an orphan translator comment{% endcomment %}
```
and run
```shell
./manage.py transifex migrate  --review=file --mark=string-low --save=none --file comments.html
```