### PR TITLE
Allow '=' in first arg of tag if string literal

### DIFF
--- a/tests/native/django/test_templatetag.py
+++ b/tests/native/django/test_templatetag.py
@@ -38,6 +38,15 @@ def test_simple():
     assert do_test('{% t "hello world" %}') == "hello world"
 
 
+def test_equal_sign():
+    # '=' in first arg means parameter and thus block syntax
+    assert do_test('{% t var="world" %}hello {var}{% endt %}') == "hello world"
+
+    # '=' in first arg when first arg is a string literal means it is not a
+    # parameter and thus inline syntax
+    assert do_test('{% t "hello=world" %}') == "hello=world"
+
+
 def test_escaping_with_t_tag_and_autoescape():
     # t-tag and autoescape means both XMLs are escaped
     assert (do_test('{% t "<xml>hello</xml> {var}" %}',

--- a/transifex/native/django/templatetags/transifex.py
+++ b/transifex/native/django/templatetags/transifex.py
@@ -61,8 +61,14 @@ def do_t(parser, token):
     has_args = bool(bits)
     # {% t |escapejs ... %} ... {% endt %}
     first_arg_is_filter = has_args and bits[0].startswith('|')
+    # {% t "hello world" ... %}
+    first_arg_is_string_literal = (has_args and
+                                   bits[0][0] in ('"', "'") and
+                                   bits[0][0] == bits[0][-1])
     # {% t var=var ... %}
-    first_arg_is_param = has_args and '=' in bits[0]
+    first_arg_is_param = (has_args and
+                          not first_arg_is_string_literal and
+                          '=' in bits[0])
     # {% t as text %}
     first_arg_is_as = has_args and bits[0] == "as"
 


### PR DESCRIPTION
Previously, we checked for the existense of a '=' on the first argument
of the t-tag to determine if it is a parameter, in which case, we
assumed the user was using the block-style syntax of the t-tag. This
obviously isn't the case if the first argument is a string literal that
has the '=' within it.