### PR TITLE
Support lazy evaluation of translations

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,4 +3,3 @@ click
 pyseeyou==1.0.0
 pytz
 requests==2.22.0
-six==1.14.0

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     ],
     url='https://github.com/transifex/transifex-python',
     install_requires=[
-        'pyseeyou', 'pytz', 'requests', 'six', 'click', 'asttokens'
+        'pyseeyou', 'pytz', 'requests', 'click', 'asttokens'
     ],
 )

--- a/tests/common/test_strings.py
+++ b/tests/common/test_strings.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
-from transifex.common.strings import printf_to_format_style
+from transifex.common.strings import (LazyString, alt_quote,
+                                      printf_to_format_style)
 
 
 def test_printf_to_format_style():
@@ -16,3 +17,53 @@ def test_printf_to_format_style():
         'This is %s and %(bar)s and %s')
     assert string == 'This is {variable_1} and {bar} and {variable_2}'
     assert set(variables) == {'variable_1', 'bar', 'variable_2'}
+
+
+def test_alt_quote():
+    assert alt_quote('"', r'This is a string') == '"'
+    assert alt_quote('"', r'This is a " string') == "'"
+    assert alt_quote('"', r'This is a \" string') == '"'
+
+    assert alt_quote("'", r"This is a string") == "'"
+    assert alt_quote("'", r"This is a ' string") == '"'
+    assert alt_quote("'", r"This is a \' string") == "'"
+
+
+class TestLazyString(object):
+    """Tests the functionality of the LazyString class."""
+
+    def test_laziness(self):
+        """Make sure the string produces the proper value when evaluates."""
+        mapping = {}
+        string = LazyString(lambda x: '{}={}'.format(x, mapping.get(x)), 'foo')
+        mapping.update({'foo': 33, 'bar': 44})
+        assert '{}'.format(string) == 'foo=33'
+
+    def test_no_memoization(self):
+        """Make sure the string produces a value every time it evaluates,
+        i.e. it does not memoize the result."""
+        mapping = {}
+        string = LazyString(
+            lambda x: '{}={}'.format(x, mapping.get(x, '<unknown>')), 'foo'
+        )
+        assert '{}'.format(string) == 'foo=<unknown>'
+        mapping.update({'foo': 33, 'bar': 44})
+        assert '{}'.format(string) == 'foo=33'
+
+    def test_str_functionality(self):
+        string = LazyString(lambda x: x * 2, 'foo')
+        assert string == 'foofoo'
+        assert len(string) == len('foofoo')
+        assert string[1] == 'o'
+        assert '.'.join([x for x in string]) == 'f.o.o.f.o.o'
+        assert 'foo' in string
+        assert 'goo' not in string
+        assert string + 'z' == 'foofooz'
+        assert 'z' + string == 'zfoofoo'
+        assert string * 2 == 'foofoofoofoo'
+        assert 2 * string == 'foofoofoofoo'
+        assert string < 'goofoo'
+        assert string > 'eoofoo'
+        assert string <= 'goofoo'
+        assert string >= 'eoofoo'
+        assert {string: 'FOO'}.get('foofoo') == 'FOO'

--- a/tests/native/core/test_tools/test_migrations/test_save.py
+++ b/tests/native/core/test_tools/test_migrations/test_save.py
@@ -1,6 +1,5 @@
-import sys
-
 from mock import mock_open, patch
+from transifex.common._compat import BUILTINS_MODULE
 from transifex.native.tools.migrations.models import (FileMigration,
                                                       StringMigration)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
@@ -8,8 +7,6 @@ from transifex.native.tools.migrations.save import (BackupSavePolicy,
                                                     NoopSavePolicy,
                                                     ReplaceSavePolicy,
                                                     SavePolicy)
-
-BUILTINS_MODULE = 'builtins' if sys.version_info >= (3, 0) else '__builtin__'
 
 
 def _file_migration():

--- a/tests/native/django/test_commands/test_migratetransifex.py
+++ b/tests/native/django/test_commands/test_migratetransifex.py
@@ -38,9 +38,10 @@ HTML_COMPILED_1 = TRANSIFEX_TEMPLATE
 
 PYTHON_SAMPLE = """
 from something import gettext
-from django.utils.translation import ugettext as _
-from django.utils.translation import something as smth, ungettext as _pl
+from django.utils.translation import ugettext as _, ugettext_lazy as _lazy
+from django.utils.translation import something as smth, ungettext as _pl, ungettext_lazy as _lazypl
 from django.utils.translation import pgettext as _ctx
+from django.utils.translation import pgettext_lazy as _lazyctx
 from django.utils.translation import ugettext as ug, to_locale, get_language_info as lang_info
 from django.utils import translation as _trans
 import django
@@ -62,8 +63,10 @@ _('This is %s and %s') % ("\\'", r"\\'")
 _('This is %(foo)s and %(bar)s') % {'foo': foo, 'bar': 'bar'}
 _('This is %(foo)s and %(bar)s') % dict(foo=foo, bar='bar')
 _('This is %s') % obj.something('else', 'is', 'happening')
+_lazy('Hello! %(name)s %(last_name)s %(age)s %(gender)s') % {'name': 'You', 'last_name': user.last_name, 'age': 33, 'gender': gender}
 
 plural = _pl('One fish', plural='Many fishes', number=number)
+plural = _lazypl('One fish', plural='Many fishes', number=number)
 django.utils.translation.ugettext('Hello!')
 
 _utils.translation.ugettext(**dict(message='Hello!'))
@@ -77,6 +80,7 @@ plural = _pl(number=number, plural='Many fishes', singular="One 'fish")
 
 withcontext1 = _ctx('Some context', 'This is a message')
 withcontext2 = _ctx(**dict(context='Some context', message='This is a message'))
+withcontext3 = _lazyctx('Some context', 'This is a message')
 
 do_something(
     django.utils.translation.ngettext('Hello!', 'Hellos!', 2),
@@ -98,7 +102,7 @@ class MyClass(object):
 
 PYTHON_SAMPLE_MIGRATED = """
 from something import gettext
-from transifex.native.django import t
+from transifex.native.django import lazyt, t
 from django.utils.translation import something as smth
 from django.utils.translation import to_locale, get_language_info as lang_info
 from django.utils import translation as _trans
@@ -121,8 +125,10 @@ t('This is {variable_1} and {variable_2}', variable_1="'", variable_2='\\'')
 t('This is {foo} and {bar}', foo=foo, bar='bar')
 t('This is {foo} and {bar}', __txnative_fixme="dict(foo=foo, bar='bar')")
 t('This is {variable_1}', variable_1=obj.something('else', 'is', 'happening'))
+lazyt('Hello! {name} {last_name} {age} {gender}', name='You', last_name=user.last_name, age=33, gender=gender)
 
 plural = t('{cnt, one {One fish} other {Many fishes}}', cnt=number)
+plural = lazyt('{cnt, one {One fish} other {Many fishes}}', cnt=number)
 t('Hello!')
 
 t('Hello!')
@@ -136,6 +142,7 @@ plural = t("{cnt, one {One 'fish} other {Many fishes}}", cnt=number)
 
 withcontext1 = t('This is a message', _context='Some context')
 withcontext2 = t('This is a message', _context='Some context')
+withcontext3 = lazyt('This is a message', _context='Some context')
 
 do_something(
     t('{cnt, one {Hello!} other {Hellos!}}', cnt=2),

--- a/tests/native/django/test_commands/test_migratetransifex.py
+++ b/tests/native/django/test_commands/test_migratetransifex.py
@@ -39,7 +39,7 @@ HTML_COMPILED_1 = TRANSIFEX_TEMPLATE
 PYTHON_SAMPLE = """
 from something import gettext
 from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext as _pl
+from django.utils.translation import something as smth, ungettext as _pl
 from django.utils.translation import pgettext as _ctx
 from django.utils.translation import ugettext as ug, to_locale, get_language_info as lang_info
 from django.utils import translation as _trans
@@ -99,6 +99,7 @@ class MyClass(object):
 PYTHON_SAMPLE_MIGRATED = """
 from something import gettext
 from transifex.native.django import t
+from django.utils.translation import something as smth
 from django.utils.translation import to_locale, get_language_info as lang_info
 from django.utils import translation as _trans
 import django

--- a/tests/native/django/test_utils/test_init.py
+++ b/tests/native/django/test_utils/test_init.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from mock import patch
+from transifex.common.strings import LazyString
+from transifex.native.django.utils import lazy_translate, translate
+
+
+def test_translate_without_translation():
+    assert translate('A string') == 'A string'
+
+
+def test_lazy_translate_without_translation():
+    string = lazy_translate('A string')
+    assert isinstance(string, LazyString)
+    assert string == 'A string'
+
+
+@patch('transifex.native.core.TxNative.get_translation')
+def test_translate_with_translation(mock_get_translation):
+    mock_get_translation.return_value = 'Γεια σου, {user}!'
+    string = translate("Doesn't matter", user='John')
+    assert string == 'Γεια σου, John!'
+
+
+@patch('transifex.native.core.TxNative.get_translation')
+def test_lazy_translate_with_translation(mock_get_translation):
+    mock_get_translation.return_value = 'Γεια σου, {user}!'
+    string = lazy_translate("Doesn't matter", user='John')
+    assert string == 'Γεια σου, John!'

--- a/transifex/common/_compat.py
+++ b/transifex/common/_compat.py
@@ -1,0 +1,16 @@
+import sys
+
+PYVER = sys.version_info[0]
+PY3 = PYVER == 3
+PY2 = PYVER == 2
+
+if PY3:
+    string_types = (str,)
+    text_type = str
+    binary_type = bytes
+else:
+    string_types = basestring,
+    text_type = unicode
+    binary_type = str
+
+BUILTINS_MODULE = 'builtins' if PY3 else '__builtin__'

--- a/transifex/common/strings.py
+++ b/transifex/common/strings.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 # i.e. matches "This is 'something" but not "This is \' something"
 import re
 
+from transifex.common._compat import text_type
+
 VAR_FORMAT = 'variable_{cnt}'
 
 RE_SINGLE_QUOTE = r"(?<!\\)\'"
@@ -24,7 +26,7 @@ def printf_to_format_style(string):
     <<< ('This is {foo} and {bar}', ['foo', 'bar'])
 
     :param unicode string: the source string
-    :return: a tuple, containing the new string (with Transifex Native syntax)
+    :return: a tuple, containing the new string (with str.format() syntax)
         and a list of the names of all variables
     :rtype: tuple
     """
@@ -36,7 +38,7 @@ def printf_to_format_style(string):
         Also stores the found variable inside `obj`.
 
         :param match: a regex match object
-        :return: a new string using ICU placeholder syntax
+        :return: a new string using str.format() placeholder syntax
         :rtype: str
         """
         # [2:-2] means from '%(foo)s' -> get 'foo'
@@ -59,7 +61,7 @@ def printf_to_format_style(string):
         Also stores the found variable inside `obj`.
 
         :param match: a regex match object
-        :return: a new string using ICU placeholder syntax
+        :return: a new string using str.format() placeholder syntax
         :rtype: str
         """
         var = VAR_FORMAT.format(cnt=str(obj['cnt']))
@@ -86,9 +88,8 @@ def alt_quote(quote, string):
     '"' (double quote)
     >>> alt_quote('"', 'This is a " string')
     "'" (single quote)
-    >>> alt_quote('"', 'This is a \" string')
+    >>> alt_quote('"', r'This is a \" string')
     '"' (double quote)
-
 
     :param unicode quote: either ' or ", the preferred quote to use for wrapping
         `string`
@@ -102,3 +103,104 @@ def alt_quote(quote, string):
     if re.search(pattern, string) and not re.search(pattern_alt, string):
         return alternate
     return quote
+
+
+class LazyString(object):
+    """Can be used instead of a string instance when delayed evaluation
+    is desired.
+
+    Upon instantiation, the caller needs to provide a function along
+    with any parameters, that will be used when the string value will be
+    evaluated.
+
+    Lazy evaluation is achieved through Pythons magic methods `__str__`
+    and `__unicode__`.
+
+    Usage:
+    In the following example, the value of 'foo' and 'bar' is not available
+    # when the string is declared (mapping is empty). However, mapping is only
+    # accessed
+    >>> mapping = {}
+    >>> string = LazyString(lambda x: '{}={}'.format(x, mapping[x]), 'foo')
+    >>> mapping.update({'foo': 33, 'bar': 44})
+    >>> print(string)
+    foo=44
+    """
+
+    def __init__(self, func, *args, **kwargs):
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+
+    def __getattr__(self, attr):
+        if attr == "__setstate__":
+            raise AttributeError(attr)
+        string = text_type(self)
+        if hasattr(string, attr):
+            return getattr(string, attr)
+        raise AttributeError(attr)
+
+    @property
+    def _resolved(self):
+        """Call the proper text_type wrapper (str() or unicode() depending
+        on the Python version) on the resolved value."""
+        return text_type(self)
+
+    def __unicode__(self):
+        """Resolve the value of the string.
+
+        Calls the evaluation function together with all parameters.
+        """
+        return text_type(self._func(*self._args, **self._kwargs))
+
+    def __str__(self):
+        """Resolve the value of the string.
+
+        Calls the evaluation function together with all parameters.
+        """
+        return self.__unicode__()
+
+    def __len__(self):
+        return len(self._resolved)
+
+    def __getitem__(self, key):
+        return self._resolved[key]
+
+    def __iter__(self):
+        return iter(self._resolved)
+
+    def __contains__(self, item):
+        return item in self._resolved
+
+    def __add__(self, other):
+        return self._resolved + other
+
+    def __radd__(self, other):
+        return other + self._resolved
+
+    def __mul__(self, other):
+        return self._resolved * other
+
+    def __rmul__(self, other):
+        return other * self._resolved
+
+    def __lt__(self, other):
+        return self._resolved < other
+
+    def __le__(self, other):
+        return self._resolved <= other
+
+    def __eq__(self, other):
+        return self._resolved == other
+
+    def __ne__(self, other):
+        return self._resolved != other
+
+    def __gt__(self, other):
+        return self._resolved > other
+
+    def __ge__(self, other):
+        return self._resolved >= other
+
+    def __hash__(self):
+        return hash(text_type(self))

--- a/transifex/common/utils.py
+++ b/transifex/common/utils.py
@@ -4,12 +4,6 @@ from datetime import datetime
 from hashlib import md5
 
 import pytz
-import six
-
-if six.PY3:
-    unicode_compat = str
-else:
-    unicode_compat = unicode
 
 
 def generate_key(source_string, context=None):

--- a/transifex/native/django/__init__.py
+++ b/transifex/native/django/__init__.py
@@ -1,3 +1,4 @@
+from transifex.native.django.utils import lazy_translate as lazyt
 from transifex.native.django.utils import translate as t
 from transifex.native.django.utils import utranslate as ut
 

--- a/transifex/native/django/management/utils/migrate.py
+++ b/transifex/native/django/management/utils/migrate.py
@@ -20,6 +20,8 @@ from transifex.native.tools.migrations.gettext import (GettextMethods,
 MIGRATE_EXTENSIONS = ['html', 'txt', 'py']
 
 
+# These are the functions + arguments of the gettext wrappers
+# provided in Django
 GETTEXT_FUNCTIONS = {
     gettext.GETTEXT: (
         'django.utils.translation.gettext',
@@ -62,9 +64,15 @@ GETTEXT_FUNCTIONS = {
         ]
     ),
 }
+# Add lazy variants with identical arguments as the corresponding non-lazy ones
+for func_name, lazy_func_name in gettext.LAZY_MAPPING.items():
+    item = GETTEXT_FUNCTIONS[func_name]
+    GETTEXT_FUNCTIONS[lazy_func_name] = (
+        item[0] + gettext.LAZY_SUFFIX, item[1]
+    )
 
 # This is the import statement that will replace gettext imports
-T_IMPORT = 'from transifex.native.django import t'
+T_IMPORT = 'from transifex.native.django import {}'
 
 
 class Migrate(CommandMixin):

--- a/transifex/native/django/management/utils/push.py
+++ b/transifex/native/django/management/utils/push.py
@@ -61,8 +61,10 @@ class Push(CommandMixin):
         # Create an extractor for Python files, to reuse for all files
         self.python_extractor = Extractor()
         # Support `t()` and `ut()` calls made on the Django module.
-        self.python_extractor.register_functions('transifex.native.django.t',
-                                                 'transifex.native.django.ut')
+        self.python_extractor.register_functions(
+            'transifex.native.django.t',
+            'transifex.native.django.ut',
+            'transifex.native.django.lazyt')
 
         self.stats = {'processed_files': 0, 'strings': []}
 

--- a/transifex/native/django/templatetags/transifex.py
+++ b/transifex/native/django/templatetags/transifex.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 from copy import copy
 
-import six
 from django.conf import settings
 from django.template import Library, Node, TemplateSyntaxError
 from django.template.base import (BLOCK_TAG_END, BLOCK_TAG_START,
@@ -14,6 +13,7 @@ from django.template.defaulttags import token_kwargs
 from django.utils.html import escape as escape_html
 from django.utils.safestring import EscapeData, SafeData, mark_safe
 from django.utils.translation import get_language, to_locale
+from transifex.common._compat import string_types
 from transifex.native import tx
 
 register = Library()
@@ -170,7 +170,7 @@ class TNode(Node):
         self.asvar = asvar
 
     def render(self, context):
-        if isinstance(self.source_string.var, six.string_types):
+        if isinstance(self.source_string.var, string_types):
             # Tag had a string literal or used block syntax
             source_icu_template = self.source_string.var
         else:
@@ -196,7 +196,7 @@ class TNode(Node):
             # django's escape marking, we perform the escaping manually, if
             # needed.
             should_escape = (
-                isinstance(value, six.string_types) and
+                isinstance(value, string_types) and
                 ((context.autoescape and not isinstance(value, SafeData)) or
                  (not context.autoescape and isinstance(value, EscapeData)))
             )

--- a/transifex/native/django/tools/migrations/templatetags.py
+++ b/transifex/native/django/tools/migrations/templatetags.py
@@ -6,13 +6,13 @@ https://docs.djangoproject.com/en/1.11/topics/i18n/translation/
 
 from __future__ import unicode_literals
 
-import six
 from django.template.base import (TOKEN_COMMENT, TOKEN_TEXT, TOKEN_VAR,
                                   TRANSLATOR_COMMENT_MARK, DebugLexer, Parser)
 from django.template.defaulttags import token_kwargs
 from django.templatetags.i18n import do_block_translate, do_translate
 from django.utils.encoding import force_text
 from django.utils.html import escape as escape_html
+from transifex.common._compat import string_types, text_type
 from transifex.native.django.utils import templates
 from transifex.native.django.utils.templates import find_filter_identity
 from transifex.native.tools.migrations.models import (Confidence,
@@ -35,7 +35,7 @@ def _render_params(params):
     result = []
     for key, value in sorted(params.items(), key=lambda i: i[0]):
         if value and value != COMMENT_FOUND:
-            result.append('='.join((key, six.text_type(value))))
+            result.append('='.join((key, text_type(value))))
     return ' '.join(result)
 
 
@@ -435,11 +435,11 @@ class DjangoTagMigrationBuilder(object):
         # attempt changes it in any way.
         # eg `{% trans "a b" %}`            => `{% t "a b" %}`
         #    `{% trans "<xml>a</xml> b" %}` => `{% ut "<xml>a</xml> b" %}`
-        if isinstance(trans_node.filter_expression.var, six.string_types):
+        if isinstance(trans_node.filter_expression.var, string_types):
             literal = trans_node.filter_expression.var
         else:
             literal = trans_node.filter_expression.var.literal
-        if (isinstance(literal, six.string_types) and
+        if (isinstance(literal, string_types) and
                 escape_html(literal) != literal):
             tag_name = "ut"
         else:

--- a/transifex/native/django/utils/__init__.py
+++ b/transifex/native/django/utils/__init__.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.utils.translation import get_language, to_locale
+from transifex.common.strings import LazyString
 from transifex.native import tx
 
 
@@ -11,8 +12,8 @@ def translate(string, _context=None, escape=True, **params):
     If there are any placeholders to replace, they need to be passed as kwargs.
 
     :param unicode string: the source string to get the translation for
-    :param unicode _context: an optional context that gives more information about
-        the source string
+    :param unicode _context: an optional context that gives more information
+        about the source string
     :param bool escape: if True, the returned string will be HTML-escaped,
         otherwise it won't
     :return: the final translation in the current language
@@ -30,8 +31,33 @@ def translate(string, _context=None, escape=True, **params):
     )
 
 
+def lazy_translate(string, _context=None, escape=True, **params):
+    """Lazily translate the given source string to the current language.
+
+    Delays the evaluation of translating the given string until necessary.
+    This is useful in cases where the call to translate() happens
+    before any translations have been retrieved, e.g. in the definition
+    of a Python class.
+
+    See translate() for more details.
+
+    :param unicode string: the source string to get the translation for
+    :param unicode _context: an optional context that gives more information
+        about the source string
+    :param bool escape: if True, the returned string will be HTML-escaped,
+        otherwise it won't
+    :return: an object that when evaluated as a string will return
+        the final translation in the current language
+    :rtype: LazyString
+    """
+    return LazyString(
+        translate, string, _context=_context, escape=escape, **params
+    )
+
+
 def utranslate(string, _context=None, **params):
-    """Translate the given source string to the current language, without HTML escaping.
+    """Translate the given source string to the current language, without HTML
+    escaping.
 
     While the given `string` is not escaped, all `params` are, before replacing
     the placeholders inside the `string`.
@@ -41,8 +67,8 @@ def utranslate(string, _context=None, **params):
     If there are any placeholders to replace, they need to be passed as kwargs.
 
     :param unicode string: the source string to get the translation for
-    :param unicode _context: an optional context that gives more information about
-        the source string
+    :param unicode _context: an optional context that gives more information
+        about the source string
     :return: the final translation in the current language
     :rtype: unicode
     """

--- a/transifex/native/django/utils/templates.py
+++ b/transifex/native/django/utils/templates.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-import six
 from django.template.base import TOKEN_BLOCK, Lexer, Parser
 from django.utils.encoding import force_text
+from transifex.common._compat import string_types
 from transifex.native.django.templatetags.transifex import do_t
 from transifex.native.parsing import SourceString
 
@@ -43,13 +43,13 @@ def tnode_to_source_string(tnode):
         transifex.
     """
 
-    if not isinstance(tnode.source_string.var, six.string_types):
+    if not isinstance(tnode.source_string.var, string_types):
         return None
     meta = {}
     for key, value in tnode.params.items():
         if len(value.filters) != 0:
             continue
-        if isinstance(value.var, six.string_types):
+        if isinstance(value.var, string_types):
             meta[key] = value.var
         elif getattr(value.var, 'literal', None) is not None:
             meta[key] = value.var.literal

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -19,6 +19,7 @@ ENCODING_PATTERN = re.compile(r'#.*coding[:=]\s*utf-?8', re.IGNORECASE)
 # in the syntax of module.deeper_module..function
 DEFAULT_MODULES = [
     'transifex.native.translate',
+    'transifex.native.lazy_translate',
 ]
 
 

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -4,7 +4,7 @@ import ast
 import re
 from collections import namedtuple
 
-from six import string_types
+from transifex.common._compat import string_types
 from transifex.common.utils import generate_key, make_hashable
 from transifex.native import consts
 from transifex.native.consts import KEY_CONTEXT

--- a/transifex/native/rendering.py
+++ b/transifex/native/rendering.py
@@ -5,8 +5,8 @@ import xml.sax.saxutils as saxutils
 from math import ceil
 
 from pyseeyou import format
-from six import string_types
-from transifex.common.utils import import_to_python, unicode_compat
+from transifex.common._compat import string_types, text_type
+from transifex.common.utils import import_to_python
 
 logger = logging.getLogger('transifex.rendering')
 logger.addHandler(logging.StreamHandler(sys.stdout))
@@ -171,7 +171,7 @@ class PseudoTranslationPolicy(AbstractRenderingPolicy):
 
         :rtype: unicode
         """
-        return unicode_compat(source_string).translate(PseudoTranslationPolicy.TABLE)
+        return text_type(source_string).translate(PseudoTranslationPolicy.TABLE)
 
 
 class WrappedStringPolicy(AbstractRenderingPolicy):

--- a/transifex/native/tools/migrations/gettext.py
+++ b/transifex/native/tools/migrations/gettext.py
@@ -44,8 +44,6 @@ class GettextMethods(object):
     For each 3rd-party framework that uses gettext for localization, we need
     to pass different paths and arguments, so that calls to these methods
     are properly migrated.
-
-    It also contains
     """
 
     def __init__(self, **kwargs):

--- a/transifex/native/tools/migrations/gettext.py
+++ b/transifex/native/tools/migrations/gettext.py
@@ -469,26 +469,33 @@ class Transformer(object):
                     or func_name != import_obj.function:
                 continue
 
-            name = import_obj.node.names[0].name
-            asname = import_obj.node.names[0].asname or name
+            full_path = None
+            for import_unit in import_obj.node.names:
+                name = import_unit.name
+                asname = import_unit.asname or name
+                if func_name != asname:
+                    continue
 
-            try:
-                module = import_obj.node.module
-            except AttributeError:
-                module = None
+                try:
+                    module = import_obj.node.module
+                except AttributeError:
+                    module = None
 
-            if not module_path:
-                full_path = '{module}.{name}'.format(module=module, name=name)
-            else:
-                full_path = '{module}{path}.{func}'.format(
-                    module=('{}.'.format(module) if module else ''),
-                    path=module_path.replace(
-                        asname,
-                        name,
-                        1,
-                    ),
-                    func=func_name
-                )
+                if not module_path:
+                    full_path = '{module}.{name}'.format(
+                        module=module, name=name)
+                else:
+                    full_path = '{module}{path}.{func}'.format(
+                        module=('{}.'.format(module) if module else ''),
+                        path=module_path.replace(
+                            asname,
+                            name,
+                            1,
+                        ),
+                        func=func_name
+                    )
+                break
+
             gettext_type = self._methods.gettext_type_from_path(full_path)
             new_func_name, args = self._methods.tx_native_details_from_type(
                 gettext_type

--- a/transifex/native/tools/migrations/gettext.py
+++ b/transifex/native/tools/migrations/gettext.py
@@ -28,6 +28,25 @@ PGETTEXT = 'pget'
 # Pluralized string with context
 NPGETTEXT = 'npget'
 
+LAZY_SUFFIX = '_lazy'
+
+# Lazy variants
+GETTEXT_LAZY = GETTEXT + LAZY_SUFFIX
+UGETTEXT_LAZY = UGETTEXT + LAZY_SUFFIX
+NGETTEXT_LAZY = NGETTEXT + LAZY_SUFFIX
+UNGETTEXT_LAZY = UNGETTEXT + LAZY_SUFFIX
+PGETTEXT_LAZY = PGETTEXT + LAZY_SUFFIX
+NPGETTEXT_LAZY = NPGETTEXT + LAZY_SUFFIX
+
+LAZY_MAPPING = {
+    GETTEXT: GETTEXT_LAZY,
+    UGETTEXT: UGETTEXT_LAZY,
+    NGETTEXT: NGETTEXT_LAZY,
+    UNGETTEXT: UNGETTEXT_LAZY,
+    PGETTEXT: PGETTEXT_LAZY,
+    NPGETTEXT: NPGETTEXT_LAZY,
+}
+
 KEYWORD_STRING = 'string'
 KEYWORD_CONTEXT = 'context'
 KEYWORD_ONE = 'one'
@@ -106,9 +125,15 @@ class GettextMethods(object):
         params = self.methods.get(gettext_type)
         if not params:
             raise ValueError(
-                'Unregistered or invalid gettext type {}'.format(gettext_type)
+                'Unregistered or invalid gettext type "{}"'.format(
+                    gettext_type
+                )
             )
-        return 't', params[1]
+        method_name = params[0]
+        native_method_name = (
+            'lazyt' if method_name.endswith(LAZY_SUFFIX) else 't'
+        )
+        return native_method_name, params[1]
 
     @property
     def all(self):
@@ -189,6 +214,8 @@ class Transformer(object):
         """
         self.errors = []
         self._methods = methods
+        if not import_statement.endswith('\n'):
+            import_statement = '{}\n'.format(import_statement)
         self.import_statement = import_statement
         self._functions = []
         self.register_functions(*self._methods.all)
@@ -302,6 +329,16 @@ class Transformer(object):
                                 key=lambda n: text_ranges[n][0])
 
             import_added = False
+
+            # Create a migration for adding the import statement
+            # of Native. At this moment we don't know if it will need
+            # to include t, lazyt or both, but we'll update the instance
+            # after all nodes have been processed
+            native_import_string_migration = StringMigration(
+                '', ''
+            )
+            native_functions = set()  # will store 't'/'lazyt' if found later
+
             for node in to_migrate:
                 text_range = text_ranges[node]
                 add_in_between(text_range)
@@ -316,17 +353,21 @@ class Transformer(object):
                     # than gettext calls
                     if isinstance(node, ast.ImportFrom):
                         try:
-                            new = self._transform_import(
-                                visitor, node, import_added
-                            )
+                            #
+                            if not import_added:
+                                file_migration.add_string(
+                                    native_import_string_migration
+                                )
+                            new, item_native_functions = self._transform_import(
+                                visitor, node)
                             confidence = Confidence.HIGH
                             import_added = True
+                            native_functions.update(item_native_functions)
 
-                            # If an import to `t` has already been added,
-                            # any other gettext translation import will be
-                            # replaced by an empty string. In that case,
+                            # If the whole import statement was about gettext
+                            # functions, a new empty line will have been
+                            # added to the file. In that case,
                             # this will also remove the empty line completely
-                            # instead of leaving extra empty lines
                             if new == '' and \
                                     node.first_token.line == original + '\n':
                                 text_range = (text_range[0], text_range[1] + 1)
@@ -385,9 +426,18 @@ class Transformer(object):
                     StringMigration(original=original, new=original)
                 )
 
+            # Update the Native import statement with the proper functions
+            if native_functions:
+                native_import_string_migration.update(
+                    extra_original='',
+                    extra_new=self.import_statement.format(
+                        ', '.join(sorted(native_functions))
+                    )
+                )
+
             return file_migration
 
-    def _transform_import(self, visitor, import_node, import_added):
+    def _transform_import(self, visitor, import_node):
         """Make sure any imports that are not related to gettext
         translations are not removed in the migrated string.
 
@@ -407,24 +457,18 @@ class Transformer(object):
 
         :param CallDetectionVisitor visitor: the visitor object
         :param ast.Node import_node: the Import or ImportFrom node
-        :param bool import_added: True if the migrated import statement
-            has already been added to the file, false otherwise
         :return: a new string to be used as the "new" migration string
         :rtype: unicode
         """
-        new = (
-            self.import_statement if not import_added
-            else ''
-        )
         if isinstance(import_node, ast.Import):
-            return new
+            return '', []
 
         full_registered_paths = ['{}.{}'.format(x['modules'], x['function'])
                                  for x in self._functions]
 
         imports_per_node = visitor.imports_per_node.get(import_node)
         if not imports_per_node:
-            return new
+            return '', []
 
         imports = visitor.imports_per_node[import_node]['imports']
         module = visitor.imports_per_node[import_node]['module']
@@ -437,12 +481,19 @@ class Transformer(object):
             if full_path not in full_registered_paths:
                 imports_to_keep.append(unit)
 
+        method_names = [
+            self._methods.gettext_type_from_path(x[1])
+            for x in all_import_units
+        ]
+        function_names = [
+            'lazyt' if method_name.endswith(LAZY_SUFFIX) else 't'
+            for method_name in method_names
+            if method_name is not None
+        ]
         if not imports_to_keep:
-            return new
+            return '', function_names
 
-        return '{migrated}{newline}from {module} import {units}'.format(
-            migrated=new,
-            newline=('\n' if new != '' else ''),
+        new_string = 'from {module} import {units}'.format(
             module=module,
             units=', '.join([
                 '{} as {}'.format(
@@ -452,6 +503,7 @@ class Transformer(object):
                 for unit in imports_to_keep
             ])
         )
+        return new_string, function_names
 
     def _transform_call(self, func_call_node, visitor, attree):
         """Transform a function call to Transifex Native format.
@@ -469,34 +521,39 @@ class Transformer(object):
                     or func_name != import_obj.function:
                 continue
 
-            full_path = None
             for import_unit in import_obj.node.names:
                 name = import_unit.name
                 asname = import_unit.asname or name
-                if func_name != asname:
-                    continue
+                if func_name == asname:
+                    break
 
-                try:
-                    module = import_obj.node.module
-                except AttributeError:
-                    module = None
+            try:
+                module = import_obj.node.module
+            except AttributeError:
+                module = None
 
-                if not module_path:
-                    full_path = '{module}.{name}'.format(
-                        module=module, name=name)
-                else:
-                    full_path = '{module}{path}.{func}'.format(
-                        module=('{}.'.format(module) if module else ''),
-                        path=module_path.replace(
-                            asname,
-                            name,
-                            1,
-                        ),
-                        func=func_name
-                    )
-                break
+            if not module_path:
+                full_path = '{module}.{name}'.format(
+                    module=module, name=name)
+            else:
+                full_path = '{module}{path}.{func}'.format(
+                    module=('{}.'.format(module) if module else ''),
+                    path=module_path.replace(
+                        asname,
+                        name,
+                        1,
+                    ),
+                    func=func_name
+                )
+
+            if not full_path:
+                name = import_obj.node.names[0].name
+                asname = import_obj.node.names[0].asname or name
 
             gettext_type = self._methods.gettext_type_from_path(full_path)
+            if gettext_type is None:
+                continue
+
             new_func_name, args = self._methods.tx_native_details_from_type(
                 gettext_type
             )
@@ -761,13 +818,13 @@ class Transformer(object):
                     break
 
         # Simple string
-        if gettext_type in (GETTEXT, UGETTEXT):
+        if gettext_type in (GETTEXT, UGETTEXT, GETTEXT_LAZY, UGETTEXT_LAZY):
             string, quote = new_arguments[KEYWORD_STRING]
             return [replace_quotes('"{}"', quote).format(string)], \
                 Confidence.HIGH
 
         # Pluralized string
-        if gettext_type in (NGETTEXT, UNGETTEXT, NPGETTEXT):
+        if gettext_type in (NGETTEXT, UNGETTEXT, NPGETTEXT, NGETTEXT_LAZY, UNGETTEXT_LAZY, NPGETTEXT_LAZY):
             one, quote_one = new_arguments[KEYWORD_ONE]
             other, quote_other = new_arguments[KEYWORD_OTHER]
 
@@ -796,7 +853,7 @@ class Transformer(object):
             return [''.join([str(x) for x in items])], confidence
 
         # String with context
-        if gettext_type == PGETTEXT:
+        if gettext_type in (PGETTEXT, PGETTEXT_LAZY):
             string, string_quote = new_arguments[KEYWORD_STRING]
             context, quote_context = new_arguments[KEYWORD_CONTEXT]
             string = replace_quotes('"{}"', string_quote).format(string)


### PR DESCRIPTION
Previously Transifex Native didn't lazy evaluation for translations. With this PR, we add support for lazy translations, with the use of `lazy_translate` (and its Django wrapper `lazyt`).

Strings wrapped with the lazy variants are not evaluated when the code is executed. Instead, a `LazyString` class is created on code execution and is only evaluated when it is accessed as a string (i.e. when its `__str__` or `__unicode__` magic methods are intrinsically called.

Also, this PR updates the Python gettext migration script to detect and properly transform all lazy variants of gettext functions.

Finally, this PR removes the dependency to `six`, by adding a `_compat` module.