### PR TITLE
Fix encoding error during file save

### DIFF
--- a/tests/native/core/test_parsing.py
+++ b/tests/native/core/test_parsing.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+import re
+
 from transifex.native.parsing import Extractor, SourceString
 
 TEMPLATE = u"""
@@ -119,9 +122,12 @@ class TestExtractor(object):
         assert results == []
         assert ex.errors[0][0] == 'myfile.py'
         assert isinstance(ex.errors[0][1], AttributeError)
-        assert ex.errors[0][1].args[0] == (
-            u"Invalid module/function format on line 6 col 0: "
-            u"'Num' object has no attribute 'attr'"
+        # Num/Constant discrepancy between python versions
+        assert re.search(
+            re.escape("Invalid module/function format on line 6 col 0: '") +
+            r'Num|Constant' +
+            re.escape("' object has no attribute 'attr'"),
+            ex.errors[0][1].args[0]
         )
 
     def _assert(self, src):

--- a/tests/native/core/test_tools/test_migrations/test_save.py
+++ b/tests/native/core/test_tools/test_migrations/test_save.py
@@ -1,5 +1,4 @@
 from mock import mock_open, patch
-from transifex.common._compat import BUILTINS_MODULE
 from transifex.native.tools.migrations.models import (FileMigration,
                                                       StringMigration)
 from transifex.native.tools.migrations.save import (BackupSavePolicy,
@@ -19,7 +18,7 @@ def _file_migration():
 def test_noop_policy_does_not_open_file():
     policy = NoopSavePolicy()
     m = mock_open()
-    with patch(BUILTINS_MODULE + ".open", m, create=True):
+    with patch("io.open", m, create=True):
         saved, error_type = policy.save_file(_file_migration())
         assert saved is False
         assert error_type is None
@@ -29,19 +28,20 @@ def test_noop_policy_does_not_open_file():
 def test_new_file_policy_writes_to_new_file():
     policy = NewFileSavePolicy()
     m = mock_open()
-    with patch(BUILTINS_MODULE + ".open", m, create=True):
+    with patch("io.open", m, create=True):
         saved, error_type = policy.save_file(_file_migration())
         assert saved is True
         assert error_type is None
 
-    m.assert_called_once_with('path/filename__native.html', 'w')
+    m.assert_called_once_with('path/filename__native.html', 'w',
+                              encoding="utf-8")
     m().write.assert_called_once_with('the migrated content')
 
 
 def test_backup_policy_writes_to_original_file_and_takes_backup():
     policy = BackupSavePolicy()
     m = mock_open()
-    with patch(BUILTINS_MODULE + ".open", m, create=True):
+    with patch("io.open", m, create=True):
         saved, error_type = policy.save_file(_file_migration())
         assert saved is True
         assert error_type is None
@@ -56,12 +56,12 @@ def test_backup_policy_writes_to_original_file_and_takes_backup():
 def test_in_place_policy_writes_to_original_file():
     policy = ReplaceSavePolicy()
     m = mock_open()
-    with patch(BUILTINS_MODULE + ".open", m, create=True):
+    with patch("io.open", m, create=True):
         saved, error_type = policy.save_file(_file_migration())
         assert saved is True
         assert error_type is None
 
-    m.assert_called_once_with('path/filename.html', 'w')
+    m.assert_called_once_with('path/filename.html', 'w', encoding="utf-8")
     m().write.assert_called_once_with('the migrated content')
 
 
@@ -72,7 +72,7 @@ def test_safe_save_handles_io_error(mock_echo):
 
     policy = SavePolicy()
     m = mock_open()
-    with patch(BUILTINS_MODULE + ".open", m, create=True):
+    with patch("io.open", m, create=True):
         saved, error_type = policy._safe_save(
             'doesnt-matter', raise_error, 'Dummy')
         assert saved is False
@@ -88,7 +88,7 @@ def test_safe_save_handles_any_error(mock_echo):
 
     policy = SavePolicy()
     m = mock_open()
-    with patch(BUILTINS_MODULE + ".open", m, create=True):
+    with patch("io.open", m, create=True):
         saved, error_type = policy._safe_save(
             'doesnt-matter', raise_error, 'Dummy')
         assert saved is False

--- a/transifex/common/_compat.py
+++ b/transifex/common/_compat.py
@@ -12,5 +12,3 @@ else:
     string_types = basestring,
     text_type = unicode
     binary_type = str
-
-BUILTINS_MODULE = 'builtins' if PY3 else '__builtin__'

--- a/transifex/native/tools/migrations/save.py
+++ b/transifex/native/tools/migrations/save.py
@@ -7,6 +7,7 @@ to the proper target, saving a backup and so on.
 """
 from __future__ import unicode_literals
 
+import io
 import os
 
 from transifex.common.console import Color
@@ -70,7 +71,7 @@ class SavePolicy(object):
         :rtype: Tuple[bool, type]
         """
         try:
-            with open(path, "w") as f:
+            with io.open(path, "w", encoding="utf-8") as f:
                 f.write(content_func())
                 Color.echo(
                     '💾️ {} file saved at [file]{}[end]'.format(file_type, path)


### PR DESCRIPTION
The compiled migrated file is a unicode string while, in python 2, the
`open` function returns a file descriptor that accepts binary content.
To go around this, we use `io.open` which accepts an encoding setting
and accepts unicode strings.