### PR TITLE
Refactor key creation

### DIFF
--- a/tests/common/test_is_plural.py
+++ b/tests/common/test_is_plural.py
@@ -1,24 +1,41 @@
-from transifex.common.utils import is_plural
+from transifex.common.utils import parse_plurals
 
 
 def test_simple():
-    assert not is_plural("hello world")
-    assert is_plural("{cnt, plural, one {ONE} other {OTHER}}")
-    assert is_plural("{cnt, plural, one {ONE} =5 {OTHER}}")
-    assert is_plural("{cnt, plural, =1 {ONE} other {OTHER}}")
-    assert is_plural("{cnt, plural, =1 {ONE} =5 {OTHER}}")
+    assert (False, {5: "hello world"}) == parse_plurals("hello world")
+
+    assert (True, {1: 'ONE', 5: 'OTHER'}) == \
+        parse_plurals("{cnt, plural, one {ONE} other {OTHER}}")
+
+    assert (True, {1: 'ONE', 5: 'OTHER'}) == \
+        parse_plurals("{cnt, plural, one {ONE} =5 {OTHER}}")
+
+    assert (True, {1: 'ONE', 5: 'OTHER'}) == \
+        parse_plurals("{cnt, plural, =1 {ONE} other {OTHER}}")
+
+    assert (True, {1: 'ONE', 5: 'OTHER'}) == \
+        parse_plurals("{cnt, plural, =1 {ONE} =5 {OTHER}}")
 
 
 def test_almost_plural():
-    assert not is_plural("{cnt, plural, one {ONE} other {OTHER}")
-    assert not is_plural("{cnt, plurall, one {ONE} other {OTHER}}")
-    assert not is_plural("{cnt, plural, onee {ONE} other {OTHER}}")
-    assert not is_plural("{cnt, plural, =7 {ONE} other {OTHER}}")
-    assert not is_plural("{cnt, plural, one {ONE}, other {OTHER}}")
-    assert not is_plural("{cnt, plural, one {ONE} many {OTHER}}")
-    assert not is_plural("{cnt, plural, one {ONE}}")
+    assert (False, {5: "{cnt, plural, one {ONE} other {OTHER}"}) ==\
+        parse_plurals("{cnt, plural, one {ONE} other {OTHER}")
+    assert (False, {5: "{cnt, plurall, one {ONE} other {OTHER}}"}) ==\
+        parse_plurals("{cnt, plurall, one {ONE} other {OTHER}}")
+    assert (False, {5: "{cnt, plural, onee {ONE} other {OTHER}}"}) ==\
+        parse_plurals("{cnt, plural, onee {ONE} other {OTHER}}")
+    assert (False, {5: "{cnt, plural, =7 {ONE} other {OTHER}}"}) ==\
+        parse_plurals("{cnt, plural, =7 {ONE} other {OTHER}}")
+    assert (False, {5: "{cnt, plural, one {ONE}, other {OTHER}}"}) ==\
+        parse_plurals("{cnt, plural, one {ONE}, other {OTHER}}")
+    assert (False, {5: "{cnt, plural, one {ONE} many {OTHER}}"}) ==\
+        parse_plurals("{cnt, plural, one {ONE} many {OTHER}}")
+    assert (False, {5: "{cnt, plural, one {ONE}}"}) ==\
+        parse_plurals("{cnt, plural, one {ONE}}")
 
 
 def test_escapes():
-    assert is_plural("{cnt, plural, one {O '' NE} other {OTHER}}")
-    assert is_plural("{cnt, plural, one {O '{ NE'} other {OTHER}}")
+    assert (True, {1: "O '' NE", 5: 'OTHER'}) == \
+        parse_plurals("{cnt, plural, one {O '' NE} other {OTHER}}")
+    assert (True, {1: "O '{ NE'", 5: 'OTHER'}) == \
+        parse_plurals("{cnt, plural, one {O '{ NE'} other {OTHER}}")

--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -103,7 +103,8 @@ class TestNative(object):
         mock_cache.return_value = None
         mytx = self._get_tx()
         mytx.translate('My String', 'en', is_source=False)
-        mock_cache.assert_called_once_with(generate_key('My String'), 'en')
+        mock_cache.assert_called_once_with(
+            generate_key(string='My String'), 'en')
         mock_render.assert_called_once_with(
             source_string='My String',
             string_to_render=None,

--- a/tests/native/django/test_templatetag.py
+++ b/tests/native/django/test_templatetag.py
@@ -395,7 +395,7 @@ def test_safe_and_escape_filter_on_block_ignored():
 
 
 def test_translates():
-    hello_key = generate_key('hello', None)
+    hello_key = generate_key(string='hello', context=None)
     tx._cache.update({'fr': (True, {hello_key: {'string': "bonjour"}})})
     assert do_test('{% t "hello" %}', lang_code="fr") == "bonjour"
 
@@ -407,7 +407,7 @@ def test_translation_missing():
     tx._cache._translations_by_lang = {}
     assert do_test('{% t "hello" %}', lang_code="fr") == "hello"
 
-    hello_key = generate_key('hello', None)
+    hello_key = generate_key(string='hello', context=None)
     tx._cache.update({'fr': (True, {hello_key: {'string': None}})})
     assert do_test('{% t "hello" %}', lang_code="fr") == "hello"
 
@@ -415,7 +415,7 @@ def test_translation_missing():
 
 
 def test_escaping_is_done_on_translation():
-    hello_key = generate_key('hello', None)
+    hello_key = generate_key(string='hello', context=None)
     tx._cache.update(
         {'fr': (True, {hello_key: {'string': "<xml>bonjour</xml>"}})})
     assert (do_test('{% t "hello" %}', lang_code="fr") ==
@@ -424,8 +424,8 @@ def test_escaping_is_done_on_translation():
 
 def test_source_filter_is_applied_on_translation():
     # 'hello' => 'bonjour', 'HELLO' => 'I like pancakes'
-    hello_key = generate_key('hello', None)
-    HELLO_key = generate_key('HELLO', None)
+    hello_key = generate_key(string='hello', context=None)
+    HELLO_key = generate_key(string='HELLO', context=None)
     tx._cache.update(
         {'fr': (
             True,

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import json
 
-from transifex.common.utils import generate_key, is_plural
+from transifex.common.utils import generate_key, parse_plurals
 from transifex.native.cache import MemoryCache
 from transifex.native.cds import CDSHandler
 from transifex.native.rendering import (SourceStringErrorPolicy,
@@ -109,10 +109,10 @@ class TxNative(object):
         if is_source:
             translation_template = source_string
         else:
-            key = generate_key(source_string, _context)
+            pluralized, plurals = parse_plurals(source_string)
+            key = generate_key(string=source_string, context=_context)
             translation_template = self._cache.get(key, language_code)
-            if (translation_template is not None and
-                    is_plural(source_string) and
+            if (translation_template is not None and pluralized and
                     translation_template.startswith('{???')):
                 variable_name = source_string[1:source_string.index(',')].\
                     strip()

--- a/transifex/native/django/management/common.py
+++ b/transifex/native/django/management/common.py
@@ -44,7 +44,9 @@ class SourceStringCollection(object):
 
         :param SourceString source_string: the object to add
         """
-        key = generate_key(source_string.string, source_string.context)
+        key = generate_key(
+            string=source_string.string, context=source_string.context
+        )
         if key not in self.strings:
             self.strings[key] = source_string
         else:

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -5,7 +5,7 @@ import re
 from collections import namedtuple
 
 from transifex.common._compat import string_types
-from transifex.common.utils import generate_key, make_hashable
+from transifex.common.utils import generate_key, make_hashable, parse_plurals
 from transifex.native import consts
 from transifex.native.consts import KEY_CONTEXT, KEY_OCCURRENCES
 
@@ -36,7 +36,8 @@ class SourceString(object):
         :param unicode _context: an optional context that accompanies
             the source string
         """
-        self.key = generate_key(string, context=_context)
+
+        self.key = generate_key(string=string, context=_context)
         self.string = string
         self.context = (
             [x.strip() for x in _context.split(',')] if _context


### PR DESCRIPTION
It's best to use the translatable content of the ICU message (and not the ICU elements) to produce the key. This way:

* Developers can change the ICU elements without changing the content and not affect the key
* We can predict the hashes on Transifex's side (useful to migrate the old resource to a new, `FILELESS` one)