### PR TITLE
Fix argument conflicts because of **params

### DIFF
--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -8,7 +8,6 @@ from transifex.native.cds import TRANSIFEX_CDS_HOST
 from transifex.native.core import NotInitializedError, TxNative
 from transifex.native.parsing import SourceString
 from transifex.native.rendering import (PseudoTranslationPolicy,
-                                        SourceStringErrorPolicy,
                                         SourceStringPolicy, parse_error_policy)
 
 
@@ -94,6 +93,7 @@ class TestNative(object):
             language_code='en',
             escape=True,
             missing_policy=mytx._missing_policy,
+            params={},
         )
 
     @patch('transifex.native.core.MemoryCache.get')
@@ -111,6 +111,7 @@ class TestNative(object):
             language_code='en',
             escape=True,
             missing_policy=mytx._missing_policy,
+            params={},
         )
 
     def test_translate_target_language_missing_reaches_missing_policy(self):
@@ -127,7 +128,7 @@ class TestNative(object):
         mytx.translate('My String', 'en', is_source=False)
         error_policy.get.assert_called_once_with(
             source_string='My String', translation=None, language_code='en',
-            escape=True
+            escape=True, params={},
         )
 
     def test_translate_error_reaches_source_string_error_policy(

--- a/tests/native/core/test_rendering.py
+++ b/tests/native/core/test_rendering.py
@@ -42,7 +42,7 @@ class TestStringRenderer(object):
             'en',
             escape=True,
             missing_policy=SourceStringPolicy(),
-            cnt=2,
+            params={'cnt': 2},
         )
         assert translation == (
             u'&lt;script type=&quot;text/javascript&quot;&gt;alert(1)&lt;/script&gt;'
@@ -55,7 +55,7 @@ class TestStringRenderer(object):
             'en',
             escape=False,
             missing_policy=SourceStringPolicy(),
-            cnt=2,
+            params={'cnt': 2},
         )
         assert translation == JS_SCRIPT
 
@@ -66,7 +66,7 @@ class TestStringRenderer(object):
             'en',
             escape=True,
             missing_policy=SourceStringPolicy(),
-            cnt=2,
+            params={'cnt': 2},
         )
         assert translation == u'2 τραπέζια'
 
@@ -77,7 +77,7 @@ class TestStringRenderer(object):
             'en',
             escape=True,
             missing_policy=SourceStringPolicy(),
-            cnt=2,
+            params={'cnt': 2},
         )
         # Should fall back to source
         assert translation == u'2 tables'
@@ -88,7 +88,7 @@ class TestStringRenderer(object):
             'en',
             escape=True,
             missing_policy=PseudoTranslationPolicy(),
-            cnt=2,
+            params={'cnt': 2},
         )
         # Should use the proper missing policy
         assert translation == u'2 ťàƀĺêš'
@@ -100,7 +100,7 @@ class TestStringRenderer(object):
             'en',
             escape=True,
             missing_policy=SourceStringPolicy(),
-            cnt=2,
+            params={'cnt': 2},
         )
         assert translation == (
             u'&lt;script type=&quot;text/javascript&quot;&gt;alert(1)&lt;/script&gt;'
@@ -113,7 +113,7 @@ class TestStringRenderer(object):
             'en',
             escape=False,
             missing_policy=SourceStringPolicy(),
-            cnt=2,
+            params={'cnt': 2},
         )
         assert translation == JS_SCRIPT
 
@@ -131,15 +131,15 @@ class TestStringRenderer(object):
         assert translation == u'Jane invites Joe and 9 other people to her party.'
 
     def _complex(self, **params):
+        params = dict(params)
+        params.update({'host': "Jane", 'guest': "Joe"})
         return StringRenderer.render(
             COMPLEX_STRINGS,
             None,
             'en',
             escape=True,
             missing_policy=SourceStringPolicy(),
-            host='Jane',
-            guest='Joe',
-            **params
+            params=params,
         )
 
     @patch('transifex.native.rendering.html_escape')

--- a/transifex/common/console.py
+++ b/transifex/common/console.py
@@ -84,5 +84,5 @@ def pluralized(one, other, cnt_value):
         language_code='en',
         escape=False,
         missing_policy=None,
-        cnt=cnt_value,
+        params={'cnt': cnt_value},
     )

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -84,6 +84,10 @@ class TxNative(object):
         :return: the rendered string
         :rtype: unicode
         """
+
+        if params is None:
+            params = {}
+
         self._check_initialization()
 
         translation_template = self.get_translation(source_string,
@@ -92,7 +96,7 @@ class TxNative(object):
                                                     is_source)
 
         return self.render_translation(translation_template,
-                                       params or {},
+                                       params,
                                        source_string,
                                        language_code,
                                        escape)
@@ -132,14 +136,14 @@ class TxNative(object):
                 language_code=language_code,
                 escape=escape,
                 missing_policy=self._missing_policy,
-                **params
+                params=params,
             )
         except Exception:
             return self._error_policy.get(
                 source_string=source_string,
                 translation=translation_template,
                 language_code=language_code,
-                escape=escape, **params
+                escape=escape, params=params,
             )
 
     def fetch_translations(self):

--- a/transifex/native/django/utils/__init__.py
+++ b/transifex/native/django/utils/__init__.py
@@ -4,17 +4,17 @@ from transifex.common.strings import LazyString
 from transifex.native import tx
 
 
-def translate(string, _context=None, escape=True, **params):
+def translate(_string, _context=None, _escape=True, **params):
     """Translate the given source string to the current language.
 
     A convenience wrapper that uses the current language of a Django app.
 
     If there are any placeholders to replace, they need to be passed as kwargs.
 
-    :param unicode string: the source string to get the translation for
+    :param unicode _string: the source string to get the translation for
     :param unicode _context: an optional context that gives more information
         about the source string
-    :param bool escape: if True, the returned string will be HTML-escaped,
+    :param bool _escape: if True, the returned string will be HTML-escaped,
         otherwise it won't
     :return: the final translation in the current language
     :rtype: unicode
@@ -22,16 +22,16 @@ def translate(string, _context=None, escape=True, **params):
     is_source = get_language() == settings.LANGUAGE_CODE
     locale = to_locale(get_language())  # e.g. from en-us to en_US
     return tx.translate(
-        string,
+        _string,
         locale,
         _context=_context,
         is_source=is_source,
-        escape=escape,
+        escape=_escape,
         params=params,
     )
 
 
-def lazy_translate(string, _context=None, escape=True, **params):
+def lazy_translate(_string, _context=None, _escape=True, **params):
     """Lazily translate the given source string to the current language.
 
     Delays the evaluation of translating the given string until necessary.
@@ -41,21 +41,21 @@ def lazy_translate(string, _context=None, escape=True, **params):
 
     See translate() for more details.
 
-    :param unicode string: the source string to get the translation for
+    :param unicode _string: the source string to get the translation for
     :param unicode _context: an optional context that gives more information
         about the source string
-    :param bool escape: if True, the returned string will be HTML-escaped,
+    :param bool _escape: if True, the returned string will be HTML-escaped,
         otherwise it won't
     :return: an object that when evaluated as a string will return
         the final translation in the current language
     :rtype: LazyString
     """
     return LazyString(
-        translate, string, _context=_context, escape=escape, **params
+        translate, _string, _context=_context, escape=_escape, **params
     )
 
 
-def utranslate(string, _context=None, **params):
+def utranslate(_string, _context=None, **params):
     """Translate the given source string to the current language, without HTML
     escaping.
 
@@ -66,10 +66,10 @@ def utranslate(string, _context=None, **params):
 
     If there are any placeholders to replace, they need to be passed as kwargs.
 
-    :param unicode string: the source string to get the translation for
+    :param unicode _string: the source string to get the translation for
     :param unicode _context: an optional context that gives more information
         about the source string
     :return: the final translation in the current language
     :rtype: unicode
     """
-    return translate(string, _context, escape=False, **params)
+    return translate(_string, _context, escape=False, **params)

--- a/transifex/native/rendering.py
+++ b/transifex/native/rendering.py
@@ -37,7 +37,7 @@ class StringRenderer(object):
     @classmethod
     def render(
         cls, source_string, string_to_render, language_code, escape,
-        missing_policy, **params
+        missing_policy, params=None,
     ):
         """Render the given ICU string.
 
@@ -61,6 +61,10 @@ class StringRenderer(object):
         :return: the final rendered string
         :rtype: unicode
         """
+
+        if params is None:
+            params = {}
+
         try:
             if not string_to_render and not missing_policy:
                 raise Exception(
@@ -294,10 +298,8 @@ class AbstractErrorPolicy(object):
     Error policies define what happens when rendering faces an error.
     They are useful to protect the user from pages failing to load."""
 
-    def get(
-        self, source_string, translation, language_code,
-        escape, **params
-    ):
+    def get(self, source_string, translation, language_code, escape,
+            params=None):
         raise NotImplementedError()
 
 
@@ -311,7 +313,7 @@ class SourceStringErrorPolicy(AbstractErrorPolicy):
 
     def get(
         self, source_string, translation, language_code,
-        escape, **params
+        escape, params=None,
     ):
         """Try to render the source string. If something goes wrong,
         render a custom text provided by the user.
@@ -322,6 +324,9 @@ class SourceStringErrorPolicy(AbstractErrorPolicy):
         :param bool escape: Whether to escape or not
         """
 
+        if params is None:
+            params = {}
+
         try:
             return StringRenderer.render(
                 source_string=source_string,
@@ -329,7 +334,7 @@ class SourceStringErrorPolicy(AbstractErrorPolicy):
                 language_code=language_code,
                 escape=escape,
                 missing_policy=None,
-                **params
+                params=params,
             )
         except Exception as e:
             logger.error(


### PR DESCRIPTION
The problem is that we have a chain of function calls like the following:

```python
first("foo", language_code="bar")

def first(string, **params):
    second(string, "fr", **params)

def second(string, language_code, **params):
    # ...
```

This way, we invoke `second` by providing the `language_code` argument
twice and python complains. We fix this by converting params to dict
argument, where possible.