### PR TITLE
Add a retry logic on CDS handler

### DIFF
--- a/tests/native/core/test_cds.py
+++ b/tests/native/core/test_cds.py
@@ -461,7 +461,7 @@ class TestCDSHandler(object):
             'some_token',
             host=cds_host,
         )
-        responses.add(responses.GET, cds_host + '/languages', status=202)
+        responses.add(responses.GET, cds_host + '/languages', status=500)
         responses.add(responses.GET, cds_host + '/languages', status=202)
         responses.add(responses.GET, cds_host + '/languages',
                       json={'data': [{'code': "el"},
@@ -482,7 +482,7 @@ class TestCDSHandler(object):
             'some_token',
             host=cds_host,
         )
-        responses.add(responses.GET, cds_host + '/content/el', status=202)
+        responses.add(responses.GET, cds_host + '/content/el', status=500)
         responses.add(responses.GET, cds_host + '/content/el', status=202)
         responses.add(responses.GET,
                       cds_host + '/content/el',

--- a/transifex/native/django/apps.py
+++ b/transifex/native/django/apps.py
@@ -95,7 +95,7 @@ class NativeConfig(AppConfig):
             tx.fetch_translations()
             logger.info('Starting daemon for OTA translations update')
 
-            sync_interval = native_settings.TRANSIFEX_SYNC_INTERVAL or 10*60
+            sync_interval = native_settings.TRANSIFEX_SYNC_INTERVAL or 30*60
             daemon.start_daemon(
                 interval=sync_interval
             )

--- a/transifex/native/django/settings.py
+++ b/transifex/native/django/settings.py
@@ -8,4 +8,4 @@ TRANSIFEX_ERROR_POLICY = getattr(settings, 'TRANSIFEX_ERROR_POLICY', None)
 LANGUAGES = getattr(settings, 'LANGUAGES', [])
 TRANSIFEX_SYNC_INTERVAL = getattr(settings,
                                   'TRANSIFEX_SYNC_INTERVAL',
-                                  10*60)
+                                  30*60)


### PR DESCRIPTION
Update CDS handler to be more graceful with CDS:
- Retry up to 3 times on 5xx responses when fetching languages or translations
- Update default refresh timer from 10min to 30min (CDS refreshes every 1h)