### PR TITLE
Add command to invalidate CDS

### DIFF
--- a/tests/native/django/test_commands/test_invalidatetransifex.py
+++ b/tests/native/django/test_commands/test_invalidatetransifex.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+import mock
+from django.core.management import call_command
+from transifex.common.console import Color
+from transifex.native.django.management.commands.transifex import Command
+
+PATH_INVALIDATE_CACHE = ('transifex.native.django.management.utils.push.tx.'
+                         'invalidate_cache')
+
+
+@mock.patch(PATH_INVALIDATE_CACHE)
+@mock.patch('transifex.common.console.Color.echo')
+def test_invalidate_cache_fail(mock_echo, mock_invalidate_cache):
+    mock_invalidate_cache.return_value = 500, {
+        'message': 'error message',
+        'details': 'error details',
+    }
+
+    expected = Color.format(
+        '[error]\nCould not invalidate CDS.[end]\n'
+        '[high]Status:[end] [warn]{code}[end]\n'
+        '[high]Message:[end] [warn]{message}[end]\n'.format(
+            code=500,
+            message='error message',
+        )
+    )
+
+    # Make sure it's idempotent
+    mock_echo.reset_mock()
+    command = Command()
+    call_command(command, 'invalidate')
+    actual = Color.format(mock_echo.call_args_list[1][0][0])
+    assert expected == actual
+
+
+@mock.patch(PATH_INVALIDATE_CACHE)
+@mock.patch('transifex.common.console.Color.echo')
+def test_invalidate_cache_success(mock_echo, mock_invalidate_cache):
+    mock_invalidate_cache.return_value = 200, {
+        'count': 5,
+    }
+
+    expected = Color.format(
+        '[green]\nSuccessfully invalidated CDS cache.[end]\n'
+        '[high]Status:[end] [warn]{code}[end]\n'
+        '[high]Records invalidated: {count}[end]\n'
+        '[high]Note: It might take a few minutes for '
+        'fresh content to be available\n'.format(
+            code=200,
+            count=5,
+        )
+    )
+
+    # Make sure it's idempotent
+    mock_echo.reset_mock()
+    command = Command()
+    call_command(command, 'invalidate')
+    actual = Color.format(mock_echo.call_args_list[1][0][0])
+    assert expected == actual
+
+
+@mock.patch(PATH_INVALIDATE_CACHE)
+@mock.patch('transifex.common.console.Color.echo')
+def test_purge_cache_success(mock_echo, mock_invalidate_cache):
+    mock_invalidate_cache.return_value = 200, {
+        'count': 5,
+    }
+
+    expected = Color.format(
+        '[green]\nSuccessfully purged CDS cache.[end]\n'
+        '[high]Status:[end] [warn]{code}[end]\n'
+        '[high]Records purged: {count}[end]\n'.format(
+            code=200,
+            count=5,
+        )
+    )
+
+    # Make sure it's idempotent
+    mock_echo.reset_mock()
+    command = Command()
+    call_command(command, 'invalidate', purge=True)
+    actual = Color.format(mock_echo.call_args_list[1][0][0])
+    assert expected == actual

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -167,6 +167,12 @@ class TxNative(object):
         response = self._cds_handler.push_source_strings(strings, purge)
         return response.status_code, json.loads(response.content)
 
+    def invalidate_cache(self, purge=False):
+        """Invalidate CDS cache."""
+        self._check_initialization()
+        response = self._cds_handler.invalidate_cache(purge)
+        return response.status_code, json.loads(response.content)
+
     def _check_initialization(self):
         """Raise an exception if the class has not been initialized.
 

--- a/transifex/native/django/management/commands/transifex.py
+++ b/transifex/native/django/management/commands/transifex.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.core.management import BaseCommand, CommandParser
+from transifex.native.django.management.utils.invalidate import Invalidate
 from transifex.native.django.management.utils.migrate import Migrate
 from transifex.native.django.management.utils.push import Push
 from transifex.native.django.management.utils.try_templatetag import \
@@ -13,6 +14,9 @@ class Command(BaseCommand):
         - push: Detects translatable strings in Django templates and Python
                 files, based on the syntax of Transifex Native and pushes them
                 as source strings to Transifex.
+
+        - invalidate: Invalidate CDS, forcing it to re-cache fresh
+                translations.
 
         - migrate: Migrates files using the Django i18n syntax to Transifex
                    Native syntax.
@@ -28,6 +32,7 @@ class Command(BaseCommand):
         super(Command, self).__init__(*args, **kwargs)
         self.subcommands = {'migrate': Migrate(),
                             'push': Push(),
+                            'invalidate': Invalidate(),
                             'try-templatetag': TryTemplatetag()}
 
     def add_arguments(self, parser):

--- a/transifex/native/django/management/utils/invalidate.py
+++ b/transifex/native/django/management/utils/invalidate.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import, unicode_literals
+
+from transifex.common.console import Color
+from transifex.native import tx
+from transifex.native.django.management.utils.base import CommandMixin
+
+
+class Invalidate(CommandMixin):
+    def add_arguments(self, subparsers):
+        parser = subparsers.add_parser(
+            'invalidate',
+            help=('Invalidate CDS, forcing it to re-cache fresh '
+                  'translations.'),
+        )
+        parser.add_argument(
+            '--purge', '-p', action='store_true', dest='purge', default=False,
+            help=('Force purging CDS cache instead of refreshing content '
+                  'asynchronously in the background. (not recommended)'),
+        )
+
+    def handle(self, *args, **options):
+        purge = options['purge']
+
+        if purge:
+            Color.echo('Purging CDS cache...')
+        else:
+            Color.echo('Invalidating CDS cache...')
+
+        status_code, response_content = tx.invalidate_cache(purge)
+
+        try:
+            if 200 <= status_code < 300:
+                # {"count":0}
+                count = response_content.get('count')
+                if purge:
+                    Color.echo(
+                        '[green]\nSuccessfully purged CDS cache.[end]\n'
+                        '[high]Status:[end] [warn]{code}[end]\n'
+                        '[high]Records purged: {count}[end]\n'.format(
+                            code=status_code,
+                            count=count,
+                        )
+                    )
+                else:
+                    Color.echo(
+                        '[green]\nSuccessfully invalidated CDS cache.[end]\n'
+                        '[high]Status:[end] [warn]{code}[end]\n'
+                        '[high]Records invalidated: {count}[end]\n'
+                        '[high]Note: It might take a few minutes for '
+                        'fresh content to be available\n'.format(
+                            code=status_code,
+                            count=count,
+                        )
+                    )
+            else:
+                message = response_content.get('message')
+                Color.echo(
+                    '[error]\nCould not invalidate CDS.[end]\n'
+                    '[high]Status:[end] [warn]{code}[end]\n'
+                    '[high]Message:[end] [warn]{message}[end]\n'.format(
+                        code=status_code,
+                        message=message,
+                    )
+                )
+        except Exception:
+            self.output(
+                '(Error while printing formatted report, '
+                'falling back to raw format)\n'
+                'Status: {code}\n'
+                'Content: {content}'.format(
+                    code=status_code,
+                    content=response_content,
+                )
+            )


### PR DESCRIPTION
Adds a `./manage.py transifex invalidate [--purge]` command to invalidate or purge the CDS cache.