### PR TITLE
Introducing Transifex API SDK

### DIFF
--- a/tests/api/constants.py
+++ b/tests/api/constants.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import, unicode_literals
+
+host = "https://rest.api.transifex.com"

--- a/tests/api/payloads.py
+++ b/tests/api/payloads.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import, unicode_literals
+
+from copy import deepcopy
+
+
+class Payloads(object):
+    """ Usage:
+
+        >>> payloads = Payloads('items')
+        >>> payloads[1]
+        <<< {'type': "items", 'id': "1", 'attributes': {'name': "item 1"}}
+        >>> payloads[1:4]
+        <<< [{'type': "items", 'id': "1", 'attributes': {'name': "item 1"}},
+        ...  {'type': "items", 'id': "2", 'attributes': {'name': "item 2"}},
+        ...  {'type': "items", 'id': "3", 'attributes': {'name': "item 3"}}]
+    """
+
+    def __init__(self, plural_type, singular_type=None, extra=None):
+        if singular_type is None:
+            singular_type = plural_type[:-1]  # items => item
+        if extra is None:
+            extra = {}
+
+        self.plural_type = plural_type
+        self.singular_type = singular_type
+        self.extra = deepcopy(extra)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            start = index.start if index.start is not None else 1
+            stop = index.stop
+            step = index.step if index.step is not None else 1
+            return [self._payload(i) for i in range(start, stop, step)]
+        else:
+            return self._payload(index)
+
+    def _payload(self, i):
+        result = {'type': self.plural_type,
+                  'id': str(i),
+                  'attributes': {'name': ("{} {}".
+                                          format(self.singular_type, i))}}
+        result.update(self.extra)
+        return result

--- a/tests/api/test_apis.py
+++ b/tests/api/test_apis.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, unicode_literals
+
+from transifex.api.jsonapi import JsonApi, Resource
+from transifex.api.jsonapi.auth import ULFAuthentication
+
+from .constants import host
+
+
+class ATestApi(JsonApi):
+    HOST = host
+
+
+@ATestApi.register
+class GlobalTest(Resource):
+    TYPE = "globaltests"
+
+
+test_api = ATestApi()
+
+
+def reset_setup():
+    test_api.setup(host=host, auth="test_api_key")
+    assert (test_api.make_auth_headers() ==
+            {'Authorization': "Bearer test_api_key"})
+    assert test_api.host == host
+
+
+def test_registries():
+    assert issubclass(test_api.type_registry['globaltests'], GlobalTest)
+    assert issubclass(test_api.class_registry['GlobalTest'], GlobalTest)
+
+
+def test_setup_plaintext():
+    test_api.setup(host="http://some.host", auth="another_key")
+    assert (test_api.make_auth_headers() ==
+            {'Authorization': "Bearer another_key"})
+    assert test_api.host == "http://some.host"
+    reset_setup()
+
+
+def test_setup_ulf():
+    test_api.setup(auth=ULFAuthentication('public'))
+    assert test_api.make_auth_headers() == {'Authorization': "ULF public"}
+
+    test_api.setup(auth=ULFAuthentication('public', 'secret'))
+    assert (test_api.make_auth_headers() ==
+            {'Authorization': "ULF public:secret"})
+
+    reset_setup()
+
+
+def test_setup_any_callable():
+    test_api.setup(host="http://some.host2",
+                   auth=lambda: {'Authorization': "Another key2"})
+    assert test_api.make_auth_headers() == {'Authorization': "Another key2"}
+    assert test_api.host == "http://some.host2"
+    reset_setup()

--- a/tests/api/test_bulk.py
+++ b/tests/api/test_bulk.py
@@ -30,9 +30,9 @@ def test_bulk_delete():
 
     items = [test_api.BulkItem(payload) for payload in payloads[1:6]]
     test_api.BulkItem.bulk_delete([items[0],
-                          items[1].as_resource_identifier(),
-                          items[2].as_relationship(),
-                          items[3].id])
+                                   items[1].as_resource_identifier(),
+                                   items[2].as_relationship(),
+                                   items[3].id])
 
     assert len(responses.calls) == 1
     call = responses.calls[0]

--- a/tests/api/test_bulk.py
+++ b/tests/api/test_bulk.py
@@ -1,0 +1,123 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+
+import responses
+from transifex.api.jsonapi import JsonApi, Resource
+
+from .constants import host
+from .payloads import Payloads
+
+
+class ATestApi(JsonApi):
+    HOST = host
+
+
+@ATestApi.register
+class BulkItem(Resource):
+    TYPE = "bulk_items"
+
+
+test_api = ATestApi(host=host, auth="test_api_key")
+
+
+payloads = Payloads('bulk_items')
+
+
+@responses.activate
+def test_bulk_delete():
+    responses.add(responses.DELETE, "{}/bulk_items".format(host))
+
+    items = [test_api.BulkItem(payload) for payload in payloads[1:6]]
+    test_api.BulkItem.bulk_delete([items[0],
+                          items[1].as_resource_identifier(),
+                          items[2].as_relationship(),
+                          items[3].id])
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert (call.request.headers['Content-Type'] ==
+            'application/vnd.api+json;profile="bulk"')
+    assert (json.loads(call.request.body.decode())['data'] ==
+            [{'type': "bulk_items", 'id': str(i)} for i in range(1, 5)])
+
+
+@responses.activate
+def test_bulk_create():
+    response_payload = payloads[1:5]
+    for item, when in zip(response_payload, range(1, 5)):
+        item['attributes']['created'] = "now + {}".format(when)
+    responses.add(responses.POST, "{}/bulk_items".format(host),
+                  json={'data': response_payload})
+
+    result = test_api.BulkItem.bulk_create([
+        BulkItem(attributes={'name': "bulk_item 1"}),
+        {'attributes': {'name': "bulk_item 2"}},
+        ({'name': "bulk_item 3"}, None),
+        {'name': "bulk_item 4"},
+    ])
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert (call.request.headers['Content-Type'] ==
+            'application/vnd.api+json;profile="bulk"')
+    assert (json.loads(call.request.body.decode()) ==
+            {'data': [{'type': "bulk_items",
+                       'attributes': {'name': "bulk_item {}".format(i)}}
+                      for i in range(1, 5)]})
+
+    assert isinstance(result[0], BulkItem)
+    assert result[1].id == "2"
+    assert result[2] == test_api.BulkItem(id="3")
+
+    for i in range(4):
+        assert result[i].id == str(i + 1)
+        assert (result[i].name ==
+                result[i].attributes['name'] ==
+                "bulk_item {}".format(i + 1))
+        assert (result[i].created ==
+                result[i].attributes['created'] ==
+                "now + {}".format(i + 1))
+
+
+@responses.activate
+def test_bulk_update():
+    response_payload = payloads[1:6]
+    for item, when in zip(response_payload, range(1, 6)):
+        item['attributes'].update({'last_update': "now + {}".format(when),
+                                   'name': "modified name {}".format(when)})
+    responses.add(responses.PATCH, "{}/bulk_items".format(host),
+                  json={'data': response_payload})
+
+    result = test_api.BulkItem.bulk_update([
+        test_api.BulkItem(id="1", attributes={'name': "modified name 1"}),
+        {'id': "2", 'attributes': {'name': "modified name 2"}},
+        ("3", {'name': "modified name 3"}, None),
+        ("4", {'name': "modified name 4"}),
+        "5",
+    ])
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert (call.request.headers['Content-Type'] ==
+            'application/vnd.api+json;profile="bulk"')
+    assert (json.loads(call.request.body.decode()) ==
+            {'data': ([{'type': "bulk_items",
+                        'id': str(i),
+                        'attributes': {'name': "modified name {}".format(i)}}
+                       for i in range(1, 5)] +
+                      [{'type': "bulk_items", 'id': "5"}])})
+
+    assert isinstance(result[0], BulkItem)
+    assert result[1].id == "2"
+    assert result[2] == test_api.BulkItem(id="3")
+    assert result[3].name == "modified name 4"
+
+    for i in range(5):
+        assert result[i].id == str(i + 1)
+        assert (result[i].name ==
+                result[i].attributes['name'] ==
+                "modified name {}".format(i + 1))
+        assert (result[i].last_update ==
+                result[i].attributes['last_update'] ==
+                "now + {}".format(i + 1))

--- a/tests/api/test_exceptions.py
+++ b/tests/api/test_exceptions.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, unicode_literals
+
+import responses
+from transifex.api.jsonapi import JsonApi, Resource
+from transifex.api.jsonapi.exceptions import JsonApiException
+
+from .constants import host
+
+
+class ATestApi(JsonApi):
+    HOST = host
+
+
+@ATestApi.register
+class Foo(Resource):
+    TYPE = "foos"
+
+
+test_api = ATestApi(auth="test_api_key")
+
+
+@responses.activate
+def test_exception_during_create():
+    responses.add(
+        responses.POST,
+        "{}/foos".format(host),
+        json={'errors': [{
+            'status': "409",
+            'code': "conflict",
+            'title': "Conflict error",
+            'detail': "username 'Foo' is already taken",
+            'source': {'pointer': "/data/attributes/username"},
+        }]},
+        status=409,
+    )
+
+    exc = None
+    try:
+        test_api.Foo.create(attributes={'username': "Foo"})
+    except JsonApiException as e:
+        exc = e
+
+    assert exc.status == "409"
+    assert exc.code == "conflict"
+    assert exc.title == "Conflict error"
+    assert exc.detail == "username 'Foo' is already taken"
+    assert exc.source == {'pointer': "/data/attributes/username"}
+
+    assert exc.errors[0].status == "409"
+    assert exc.errors[0].code == "conflict"
+    assert exc.errors[0].title == "Conflict error"
+    assert exc.errors[0].detail == "username 'Foo' is already taken"
+    assert exc.errors[0].source == {'pointer': "/data/attributes/username"}

--- a/tests/api/test_plural_lists.py
+++ b/tests/api/test_plural_lists.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import, unicode_literals
+
+from copy import deepcopy
+
+import responses
+from transifex.api.jsonapi import JsonApi, Resource
+from transifex.api.jsonapi.compat import abc
+
+from .constants import host
+from .payloads import Payloads
+
+
+class ATestApi(JsonApi):
+    HOST = host
+
+
+@ATestApi.register
+class Child(Resource):
+    TYPE = "children"
+
+
+@ATestApi.register
+class Parent(Resource):
+    TYPE = "parents"
+
+
+test_api = ATestApi(host=host, auth="test_api_key")
+
+
+child_payloads = Payloads('children', singular_type="child")
+
+
+PAYLOAD = {'data': {
+    'type': "parents",
+    'id': "1",
+    'attributes': {'name': "parent 1"},
+    'relationships': {'children': {
+        'data': [{'type': "children", 'id': "1"},
+                 {'type': "children", 'id': "2"}],
+        'links': {'related': "/parents/1/children"},
+    }},
+}}
+
+
+def make_simple_assertions(parent):
+    assert isinstance(parent.children, abc.Sequence)
+    assert parent.children[0].id == "1"
+    assert parent.children[1].id == "2"
+
+
+def test_plural_list():
+    parent = test_api.Parent(PAYLOAD)
+    make_simple_assertions(parent)
+    parent = test_api.Parent(PAYLOAD['data'])
+    make_simple_assertions(parent)
+    parent = test_api.Parent(**PAYLOAD['data'])
+    make_simple_assertions(parent)
+
+
+def test_included():
+    payload = deepcopy(PAYLOAD)
+    payload['included'] = child_payloads[1:3]
+    parent = test_api.Parent(payload)
+    make_simple_assertions(parent)
+
+    assert parent.children[0].name == "child 1"
+    assert parent.children[1].name == "child 2"
+
+
+@responses.activate
+def test_refetch():
+    responses.add(responses.GET, "{}/parents/1/children".format(host),
+                  json={'data': child_payloads[1:4]})
+
+    parent = test_api.Parent(PAYLOAD)
+    assert len(parent.children) == 2
+
+    parent.fetch('children')
+    assert len(parent.children) == 3
+    assert ([child.name for child in parent.children] ==
+            ["child {}".format(i) for i in range(1, 4)])
+
+
+@responses.activate
+def test_save_with_included():
+    payload = deepcopy(PAYLOAD)
+    payload['included'] = child_payloads[1:3]
+    responses.add(responses.PATCH, "{}/parents/1".format(host), json=payload)
+    parent = test_api.Parent(payload)
+    parent.save(name="parent 1")
+    assert [child.name for child in parent.children] == ["child 1", "child 2"]

--- a/tests/api/test_queryset.py
+++ b/tests/api/test_queryset.py
@@ -1,0 +1,182 @@
+from __future__ import absolute_import, unicode_literals
+
+import responses
+from transifex.api.jsonapi import JsonApi, Resource
+from transifex.api.jsonapi.collections import Collection
+
+from .constants import host
+from .payloads import Payloads
+
+
+class ATestApi(JsonApi):
+    HOST = host
+
+
+@ATestApi.register
+class Item(Resource):
+    TYPE = "items"
+
+
+@ATestApi.register
+class Tag(Resource):
+    TYPE = "tags"
+
+
+test_api = ATestApi(host=host, auth="test_api_key")
+
+
+payloads = Payloads('items')
+
+
+@responses.activate
+def test_collection():
+    responses.add(responses.GET, "{}/items".format(host),
+                  json={'data': payloads[1:4]})
+
+    collection = Collection(test_api, '/items')
+    list(collection)
+
+    assert len(collection) == 3
+    assert isinstance(collection[0], Item)
+    assert collection[1].id == "2"
+    assert collection[2].name == "item 3"
+
+    assert not collection.has_next()
+    assert not collection.has_previous()
+
+    assert list(collection) == list(collection.all())
+
+
+def test_from_data():
+    collection = Collection.from_data(test_api, {'data': payloads[1:4]})
+
+    assert len(collection) == 3
+    assert isinstance(collection[0], Item)
+    assert collection[1].id == "2"
+    assert collection[2].name == "item 3"
+
+    assert not collection.has_next()
+    assert not collection.has_previous()
+
+    assert list(collection) == list(collection.all())
+
+
+@responses.activate
+def test_pagination():
+    responses.add(responses.GET, "{}/items?page=2".format(host),
+                  json={'data': payloads[4:7],
+                        'links': {'previous': "/items?page=1"}})
+
+    first_page = Collection.from_data(test_api,
+                                      {'data': payloads[1:4],
+                                       'links': {'next': "/items?page=2"}})
+    assert first_page.has_next()
+    second_page = first_page.next()
+    list(second_page)
+
+    assert len(responses.calls) == 1
+
+    assert len(second_page) == 3
+    assert isinstance(second_page[0], Item)
+    assert second_page[1].id == "5"
+    assert second_page[2].name == "item 6"
+
+    assert not second_page.has_next()
+    assert second_page.has_previous()
+
+    assert list(first_page.all()) == list(first_page) + list(second_page)
+    assert ([list(page) for page in first_page.all_pages()] ==
+            [list(first_page), list(second_page)])
+
+
+@responses.activate
+def test_all():
+    responses.add(responses.GET, "{}/items".format(host),
+                  json={'data': payloads[1:4]})
+    collection = test_api.Item.list()
+
+    assert len(collection) == 3
+    assert isinstance(collection[0], Item)
+    assert collection[1].id == "2"
+    assert collection[2].name == "item 3"
+
+    assert not collection.has_next()
+    assert not collection.has_previous()
+
+    assert list(collection) == list(collection.all())
+
+
+@responses.activate
+def test_all_with_pagination():
+    responses.add(responses.GET, "{}/items".format(host),
+                  json={'data': payloads[1:4],
+                        'links': {'next': "/items?page=2"}},
+                  match_querystring=True)
+    responses.add(responses.GET, "{}/items?page=2".format(host),
+                  json={'data': payloads[4:7],
+                        'links': {'previous': "/items?page=1"}},
+                  match_querystring=True)
+
+    first_page = test_api.Item.list()
+
+    assert first_page.has_next()
+    second_page = first_page.next()
+    list(second_page)
+
+    assert len(responses.calls) == 2
+
+    assert len(second_page) == 3
+    assert isinstance(second_page[0], Item)
+    assert second_page[1].id == "5"
+    assert second_page[2].name == "item 6"
+
+    assert not second_page.has_next()
+    assert second_page.has_previous()
+
+    assert list(first_page.all()) == list(first_page) + list(second_page)
+    assert ([list(page) for page in first_page.all_pages()] ==
+            [list(first_page), list(second_page)])
+
+
+@responses.activate
+def test_filter():
+    responses.add(responses.GET, "{}/items".format(host),
+                  json={'data': payloads[1:5]}, match_querystring=True)
+    responses.add(responses.GET, "{}/items?filter[odd]=1".format(host),
+                  json={'data': payloads[1:5:2]}, match_querystring=True)
+
+    all_items = test_api.Item.list()
+    odd_items = test_api.Item.filter(odd=1)
+
+    assert len(all_items) == 4
+    assert len(odd_items) == 2
+
+    assert list(odd_items) == [all_items[0], all_items[2]]
+
+    assert (list(test_api.Item.filter(odd=1)) ==
+            list(test_api.Item.list().filter(odd=1)) ==
+            list(test_api.Item.filter(odd=2).filter(odd=1)))
+
+
+@responses.activate
+def test_include():
+    responses.add(responses.GET, "{}/items".format(host), json={
+        'data': [{'type': "items",
+                  'id': "1",
+                  'relationships': {'tag': {'data': {'type': "tags",
+                                                     'id': "1"}}}},
+                 {'type': "items",
+                  'id': "2",
+                  'relationships': {'tag': {'data': {'type': "tags",
+                                                     'id': "2"}}}}],
+        'included': [{'type': "tags",
+                      'id': "1",
+                      'attributes': {'name': "tag1"}},
+                     {'type': "tags",
+                      'id': "2",
+                      'attributes': {'name': "tag2"}}],
+    })
+
+    item1, item2 = test_api.Item.list()
+    assert item1.tag.name == "tag1"
+    assert item2.tag.name == "tag2"

--- a/tests/api/test_relationships.py
+++ b/tests/api/test_relationships.py
@@ -1,0 +1,181 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+from copy import deepcopy
+
+import responses
+from transifex.api.jsonapi import JsonApi, Resource
+
+from .constants import host
+from .payloads import Payloads
+
+
+class ATestApi(JsonApi):
+    HOST = host
+
+
+@ATestApi.register
+class Child(Resource):
+    TYPE = "children"
+
+
+@ATestApi.register
+class Parent(Resource):
+    TYPE = "parents"
+
+
+test_api = ATestApi(auth="test_api_key")
+
+
+child_payloads = Payloads(
+    'children', 'child',
+    extra={'relationships': {
+        'parent': {'data': {'type': "parents", 'id': "1"},
+                   'links': {'self': "/children/1/relationships/parent",
+                             'related': "/parents/1"}},
+    }}
+)
+parent_payloads = Payloads(
+    'parents',
+    extra={'relationships': {
+        'children': {'links': {'self': "/parents/1/relationships/children",
+                               'related': "/parents/1/children"}},
+    }}
+)
+
+
+@responses.activate
+def test_initialization():
+    responses.add(responses.GET, "{}/parents/1".format(host),
+                  json={'data': {'type': "parents", 'id': "1"}})
+    parents = [test_api.Parent.get('1'),
+               test_api.Parent(id='1'),
+               {'data': {'type': "parents", 'id': '1'}},
+               {'type': "parents", 'id': '1'}]
+    children = [test_api.Child(relationships={'parent': parent})
+                for parent in parents]
+    assert all((children[i] == children[i + 1]
+                for i in range(len(children) - 1)))
+    assert all((children[i].__dict__ == children[i + 1].__dict__
+                for i in range(len(children) - 1)))
+    assert all((children[i].parent.__dict__ == children[i + 1].parent.__dict__
+                for i in range(len(children) - 1)))
+
+    child = test_api.Child(relationships={'parent': None})
+    assert child.relationships == child.related == {'parent': None}
+
+
+@responses.activate
+def test_singular_fetch():
+    responses.add(responses.GET, "{}/parents/1".format(host),
+                  json={'data': parent_payloads[1]})
+
+    child = test_api.Child(child_payloads[1])
+
+    assert (child.relationships ==
+            {'parent': {'data': {'type': "parents", 'id': "1"},
+                        'links': {'self': "/children/1/relationships/parent",
+                                  'related': "/parents/1"}}})
+    assert (child.related['parent'] ==
+            child.parent ==
+            test_api.Parent(id="1"))
+    assert child.parent.attributes == child.parent.attributes == {}
+
+    child.fetch('parent')
+
+    assert len(responses.calls) == 1
+    assert (child.related['parent'] ==
+            child.parent ==
+            test_api.Parent(id="1"))
+    assert child.parent.attributes == {'name': "parent 1"}
+    assert child.parent.name == "parent 1"
+
+
+@responses.activate
+def test_fetch_plural():
+    responses.add(responses.GET, "{}/parents/1/children".format(host),
+                  json={'data': child_payloads[1:4],
+                        'links': {'next': "/parents/1/children?page=2"}},
+                  match_querystring=True)
+    responses.add(responses.GET, "{}/parents/1/children?page=2".format(host),
+                  json={'data': child_payloads[4:7],
+                        'links': {'previous': "/parents/1/children?page=1"}},
+                  match_querystring=True)
+
+    parent = test_api.Parent(parent_payloads[1])
+    assert 'children' not in parent.related
+    parent.fetch('children')
+    list(parent.children)
+
+    assert len(responses.calls) == 1
+    assert 'children' in parent.related
+    assert len(parent.children) == 3
+    assert isinstance(parent.children[0], Child)
+    assert parent.children[1].id == "2"
+    assert parent.children[2].name == "child 3"
+
+    assert parent.children.has_next()
+    assert not parent.children.has_previous()
+    assert len(list(parent.children.all())) == 6
+
+
+@responses.activate
+def test_change_parent_with_save():
+    response_body = deepcopy(child_payloads[1])
+    relationship = response_body['relationships']['parent']
+    relationship['data']['id'] = 2
+    relationship['links']['related'] = relationship['links']['related'].\
+        replace('1', '2')
+
+    responses.add(responses.PATCH, "{}/children/1".format(host),
+                  json={'data': response_body})
+
+    child = test_api.Child(child_payloads[1])
+    child.parent = test_api.Parent(parent_payloads[2])
+
+    assert child.relationships['parent']['data']['id'] == "2"
+    assert child.related['parent'].id == child.parent.id == "2"
+
+    child.save()
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert (json.loads(call.request.body.decode())['data']
+            ['relationships']['parent']['data']['id'] ==
+            "2")
+
+
+@responses.activate
+def test_change_parent_with_change():
+    responses.add(responses.PATCH,
+                  "{}/children/1/relationships/parent".format(host))
+
+    child = test_api.Child(child_payloads[1])
+    new_parent = test_api.Parent(id="2")
+    child.change('parent', new_parent)
+
+    assert child.relationships['parent']['data']['id'] == "2"
+    assert child.parent.id == "2"
+    assert child.parent == new_parent
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert (json.loads(call.request.body.decode()) ==
+            new_parent.as_relationship())
+
+
+@responses.activate
+def test_add():
+    responses.add(responses.POST,
+                  "{}/parents/1/relationships/children".format(host))
+
+    parent = test_api.Parent(parent_payloads[1])
+    children = [test_api.Child(payload) for payload in child_payloads[1:4]]
+    parent.add('children', [children[0],
+                            children[1].as_relationship(),
+                            children[2].as_resource_identifier()])
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert (json.loads(call.request.body.decode())['data'] ==
+            [{'type': "children", 'id': str(i)} for i in range(1, 4)])

--- a/tests/api/test_single_resource.py
+++ b/tests/api/test_single_resource.py
@@ -1,0 +1,255 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+from copy import deepcopy
+
+import responses
+from transifex.api.jsonapi import JsonApi, Resource
+
+from .constants import host
+
+
+class ATestApi(JsonApi):
+    HOST = host
+
+
+@ATestApi.register
+class Foo(Resource):
+    TYPE = "foos"
+
+
+test_api = ATestApi(host=host, auth="test_api_key")
+
+
+SIMPLE_PAYLOAD = {'type': "foos", 'id': "1", 'attributes': {'hello': "world"}}
+
+
+def make_simple_assertions(foo):
+    assert isinstance(foo, Foo)
+    assert foo.TYPE == "foos"
+    assert foo.id == "1"
+    assert foo.attributes == {'hello': "world"}
+    assert foo.relationships == {}
+    assert foo.related == {}
+    assert foo.hello == "world"
+
+
+def test_init():
+    foo = test_api.Foo(id="1", attributes={'hello': "world"})
+    make_simple_assertions(foo)
+    foo = test_api.Foo({'data': SIMPLE_PAYLOAD})
+    make_simple_assertions(foo)
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+    make_simple_assertions(foo)
+    foo = test_api.Foo(id="1", hello="world")
+    make_simple_assertions(foo)
+
+
+def test_new():
+    foo = test_api.new(type="foos", id="1", attributes={'hello': "world"})
+    make_simple_assertions(foo)
+    foo = test_api.new({'data': SIMPLE_PAYLOAD})
+    make_simple_assertions(foo)
+    foo = test_api.new(SIMPLE_PAYLOAD)
+    make_simple_assertions(foo)
+    foo = test_api.new(type="foos", id="1", hello="world")
+    make_simple_assertions(foo)
+
+
+def test_as_resource():
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+    assert (test_api.as_resource(foo).as_resource_identifier() ==
+            {'type': "foos", 'id': "1"})
+    assert (test_api.as_resource({'data': SIMPLE_PAYLOAD}).
+            as_resource_identifier() == {'type': "foos", 'id': "1"})
+    assert (test_api.as_resource(SIMPLE_PAYLOAD).
+            as_resource_identifier() ==
+            {'type': "foos", 'id': "1"})
+
+
+def test_setattr():
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+    foo.hello = "WORLD"
+    assert foo.hello == "WORLD"
+    assert foo.attributes == {'hello': "WORLD"}
+
+
+@responses.activate
+def test_reload():
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+
+    new_payload = deepcopy(SIMPLE_PAYLOAD)
+    new_payload['attributes']['hello'] = "WORLD"
+    responses.add(responses.GET, "{}/foos/1".format(host),
+                  json={'data': new_payload})
+
+    foo.reload()
+    assert foo.hello == "WORLD"
+    assert foo.attributes == {'hello': "WORLD"}
+
+
+@responses.activate
+def test_get_one():
+    responses.add(responses.GET, "{}/foos/1".format(host),
+                  json={'data': SIMPLE_PAYLOAD})
+
+    foo = test_api.Foo.get('1')
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert call.request.headers['Content-Type'] == "application/vnd.api+json"
+    assert call.request.headers['Authorization'] == "Bearer test_api_key"
+
+    make_simple_assertions(foo)
+
+
+@responses.activate
+def test_get_one_with_filters():
+    responses.add(responses.GET, "{}/foos?filter[hello]=world".format(host),
+                  json={'data': [SIMPLE_PAYLOAD]}, match_querystring=True)
+
+    foo = test_api.Foo.get(hello="world")
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert call.request.headers['Content-Type'] == "application/vnd.api+json"
+    assert call.request.headers['Authorization'] == "Bearer test_api_key"
+
+    make_simple_assertions(foo)
+
+
+@responses.activate
+def test_get_one_with_include():
+    responses.add(
+        responses.GET,
+        "{}/foos/1".format(host),
+        json={'data': {'type': "foos",
+                       'id': "1",
+                       'attributes': {'name': "Foo1"},
+                       'relationships': {'sibling': {'data': {'type': "foos",
+                                                              'id': "2"}}}},
+              'included': [{'type': "foos",
+                            'id': "2",
+                            'attributes': {'name': "Foo2"}}]},
+    )
+
+    foo = test_api.Foo.get('1', include=['sibling'])
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert call.request.headers['Content-Type'] == "application/vnd.api+json"
+    assert call.request.headers['Authorization'] == "Bearer test_api_key"
+
+    assert isinstance(foo, Foo)
+    assert foo.TYPE == "foos"
+    assert foo.id == "1"
+    assert foo.attributes == {'name': "Foo1"}
+    assert foo.name == "Foo1"
+    assert isinstance(foo.sibling, Foo)
+    assert foo.sibling.TYPE == "foos"
+    assert foo.sibling.id == "2"
+    assert foo.sibling.attributes == {'name': "Foo2"}
+    assert foo.sibling.name == "Foo2"
+
+
+@responses.activate
+def test_save_existing():
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+
+    new_payload = deepcopy(SIMPLE_PAYLOAD)
+    new_payload['attributes']['hello'] = "WORLD"
+    responses.add(responses.PATCH, "{}/foos/1".format(host),
+                  json={'data': new_payload})
+
+    foo.hello = "WORLD"
+    foo.save()
+
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert json.loads(call.request.body.decode()) == {'data': new_payload}
+
+    foo.hello = "something else"
+    foo.save(hello="WORLD")
+
+    assert len(responses.calls) == 2
+    call = responses.calls[1]
+    assert json.loads(call.request.body.decode()) == {'data': new_payload}
+
+
+@responses.activate
+def test_save_new():
+    new_payload = deepcopy(SIMPLE_PAYLOAD)
+    new_payload['attributes']['created'] = "NOW!!!"
+    responses.add(responses.POST, "{}/foos".format(host),
+                  json={'data': new_payload})
+
+    foo = test_api.Foo(attributes={'hello': "world"})
+    foo.save()
+
+    assert foo.id == "1"
+    assert foo.created == "NOW!!!"
+    assert foo.attributes == {'hello': "world", 'created': "NOW!!!"}
+
+
+@responses.activate
+def test_create():
+    new_payload = deepcopy(SIMPLE_PAYLOAD)
+    new_payload['attributes']['created'] = "NOW!!!"
+    responses.add(responses.POST, "{}/foos".format(host),
+                  json={'data': new_payload})
+
+    foo = test_api.Foo.create(attributes={'hello': "world"})
+
+    assert foo.created == "NOW!!!"
+    assert foo.attributes == {'hello': "world", 'created': "NOW!!!"}
+
+
+@responses.activate
+def test_create_with_id():
+    new_payload = deepcopy(SIMPLE_PAYLOAD)
+    new_payload['attributes']['created'] = "NOW!!!"
+    responses.add(responses.POST, "{}/foos".format(host),
+                  json={'data': new_payload})
+
+    foo = test_api.Foo.create(id="2", attributes={'hello': "world"})
+
+    assert len(responses.calls) == 1
+    assert json.loads(responses.calls[0].request.body.decode()) == {'data': {
+        'type': "foos",
+        'id': "2",
+        'attributes': {'hello': "world"},
+    }}
+    assert foo.created == "NOW!!!"
+    assert foo.attributes == {'hello': "world", 'created': "NOW!!!"}
+    assert foo.id == "1"
+
+
+@responses.activate
+def test_delete():
+    responses.add(responses.DELETE, "{}/foos/1".format(host))
+
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+    foo.delete()
+
+    assert len(responses.calls) == 1
+    assert foo.id is None
+
+
+def test_eq():
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+    assert foo == {'type': "foos", 'id': "1"}
+    assert {'type': "foos", 'id': "1"} == foo
+    assert foo == {'data': {'type': "foos", 'id': "1"}}
+    assert {'data': {'type': "foos", 'id': "1"}} == foo
+    assert foo == test_api.Foo(id="1")
+    assert test_api.Foo(id="1") == foo
+
+
+def test_as_resource_identifier():
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+    assert foo.as_resource_identifier() == {'type': "foos", 'id': "1"}
+
+
+def test_as_relationship():
+    foo = test_api.Foo(SIMPLE_PAYLOAD)
+    assert foo.as_relationship() == {'data': {'type': "foos", 'id': "1"}}

--- a/transifex/api/README.md
+++ b/transifex/api/README.md
@@ -26,7 +26,6 @@ A python SDK for the [Transifex API (v3)](https://transifex.github.io/openapi/)
     * [Editing relationships](#editing-relationships)
     * [Bulk operations](#bulk-operations)
     * [Form uploads, redirects](#form-uploads-redirects)
-* [Testing](#testing)
 
 <!-- Added by: kbairak, at: Mon May 10 07:09:14 PM EEST 2021 -->
 
@@ -41,9 +40,9 @@ for [{json:api}](https://jsonapi.org) APIs located at the
 library maps to HTTP interactions and consult the Transifex API documentation,
 you should be able to make use of the SDK.
 
-This readme is split between two sections, one that provides an overview of how
+This readme is split between two sections: one that provides an overview of how
 to work with the Transifex API and one that shows how you can use
-`transifex.api.jsonapi` to build and SDK that can interact with *any* API that
+`transifex.api.jsonapi` to build an SDK that can interact with *any* API that
 follows the {json:api}. You should read the second part if you want to
 troubleshoot or understand how the internals of the SDK work.
 
@@ -138,8 +137,10 @@ languages = project.fetch('languages')
 
 ### Changing attributes
 
-Lets use what we've learned so far alongside the API documentation to find a
-"string translation _slot_":
+Let's use what we've learned so far alongside the API documentation to find a
+"untranslated string _slot_" (the `/resource_translations` endpoint returns
+items for strings that haven't been translated yet, setting their `strings`
+field will post a translation):
 
 ```python
 language_dict = {
@@ -225,7 +226,8 @@ to perform the change. Again, you should consult the API documentation to see
 which relationships can be changed and with which methods (in this case -
 changing a project's team - both methods are available).
 
-The `project -> team` is a "singular relationship". To change a "plural
+The `project -> team` is a "singular relationship" (singular relationships are
+either one-to-one or foreign-key relationships). To change a "plural
 relationship", like a project's target languages, you can use the `reset`,
 `add` and `remove` methods:
 
@@ -281,9 +283,8 @@ project.delete()
 
 ### File uploads and downloads
 
-There is some code in `transifex.api` that automate several {json:api}
-interactions behind the scenes in order to help with file uploads and
-downloads.
+There is code in `transifex.api` that automates several {json:api} interactions
+behind the scenes in order to help with file uploads and downloads.
 
 In order to upload a source file to a resource, you can do:
 
@@ -1324,28 +1325,3 @@ while True:
     sleep(5)
     upload.reload()
 ```
-
-## Testing
-
-To run the tests:
-
-```sh
-mkvirtualenv transifex_sdk
-pip install -e .
-pip install -r requirements/testing.txt
-make test
-```
-
-There are several variations on test commands, most targeted towards active
-development:
-
-
-- `make test`: Run tests in multiple python versions using
-  [tox](https://tox.readthedocs.io/en/latest/)
-- `make covtest`: Display coverage information using
-  [pytest-cov](https://github.com/pytest-dev/pytest-cov)
-- `make debugtest`: Disable screen capture (with `-s` option to pytest) so that
-  you can invoke a debugger while the tests are running
-- `make watchtest`: Invoke the tests with
-  [pytest-watch](https://github.com/joeyespo/pytest-watch) so that they rerun
-  every time a source python file in the repository changes

--- a/transifex/api/README.md
+++ b/transifex/api/README.md
@@ -208,7 +208,7 @@ options:
 project.team = team_2
 project.save('team')
 
-# Or 
+# Or
 
 project.save(team=team_2)
 ```

--- a/transifex/api/README.md
+++ b/transifex/api/README.md
@@ -1,0 +1,1132 @@
+A python SDK for the [Transifex API (v3)](https://transifex.github.io/openapi/)
+
+## Table of contents
+
+<!--ts-->
+* [Table of contents](#table-of-contents)
+* [Introduction](#introduction)
+* [Installation](#installation)
+* [jsonapi usage](#jsonapi-usage)
+   * [Setting up](#setting-up)
+      * [Global <em>API connection instances</em>](#global-api-connection-instances)
+      * [Authentication](#authentication)
+      * [Custom headers](#custom-headers)
+   * [Retrieval](#retrieval)
+      * [URLs](#urls)
+      * [Getting a single resource object from the API](#getting-a-single-resource-object-from-the-api)
+      * [Relationships](#relationships)
+      * [Shortcuts](#shortcuts)
+      * [Getting Resource collections](#getting-resource-collections)
+      * [Prefetching relationships with include](#prefetching-relationships-with-include)
+      * [Getting single resource objects using filters](#getting-single-resource-objects-using-filters)
+   * [Editing](#editing)
+      * [Saving changes](#saving-changes)
+      * [Creating new resources](#creating-new-resources)
+      * [Deleting](#deleting)
+      * [Editing relationships](#editing-relationships)
+      * [Bulk operations](#bulk-operations)
+      * [Form uploads, redirects](#form-uploads-redirects)
+* [transifex_api usage](#transifex_api-usage)
+* [Testing](#testing)
+
+<!-- Added by: kbairak, at: Thu Feb  4 01:35:10 PM EET 2021 -->
+
+<!--te-->
+
+## Introduction
+
+This library provides an SDK for the Transifex API: `transifex.api`. It is
+based on a low-level library for [{json:api}](https://jsonapi.org):
+`transifex.api.jsonapi`. Since the Transifex API follows the {json:api}
+guidelines, all you need to understand is how the `jsonapi` part works.
+
+## `jsonapi` usage
+
+### Setting up
+
+Using `transifex.api.jsonapi` means creating your own API SDK for a remote
+service. In order to do that, you need to first define an _API connection
+type_. This is done by subclassing `transifex.api.jsonapi.JsonApi`:
+
+```python
+from transifex.api.jsonapi import JsonApi
+
+class FamilyApi(JsonApi):
+   HOST = "https://api.families.com"
+```
+
+Next, you have to define some _API resource types_ and register them to the
+_API connection type_. This is done by subclassing
+`transifex.api.jsonapi.Resource` and decorating it with the connection type's
+`register` method:
+
+```python
+from transifex.api.jsonapi import Resource
+
+@FamilyApi.register
+class Parent(Resource):
+   TYPE = "parents"
+
+@FamilyApi.register
+class Child(Resource):
+   TYPE = "children"
+```
+
+Users of your SDK can then instantiate your _API connection type_, providing
+authentication credentials and/or overriding the host, in case you want to test
+against a sandbox API server and not the production one:
+
+```python
+family_api = FamilyApi(host="https://sandbox.api.families.com",
+                       auth="<MY_TOKEN>")
+```
+
+Finally the API resource types you have registered can be accessed as
+attributes on this _API connection instance_. You can either use the class's
+name or the API resource's type:
+
+```python
+child = family_api.Child.get('1')
+child = family_api.children.get('1')
+```
+
+This is enough to get you started since the library will be able to provide you
+with a lot of functionality based on the structure of the responses you get
+from the server. Make sure you define and register Resource subclasses for
+every type you intend to encounter, because `transifex.api.jsonapi` will use
+the API instance's registry to resolve the appropriate subclass for the items
+included in the API's responses.
+
+#### Global _API connection instances_
+
+You can configure an already created _API connection instance_ by calling the
+`setup` method, which accepts the same keyword arguments as the constructor. In
+fact, `JsonApi`'s `__init__` and `setup` methods have been written in such a
+way that the following two snippets should produce an identical outcome:
+
+```python
+kwargs = ...
+family_api = FamilyApi(**kwargs)
+```
+
+```python
+kwargs = ...
+family_api = FamilyApi()
+family_api.setup(**kwargs)
+```
+
+This way, you can implement your SDK in a way that offers the option to users
+to either use a _global API connection instance_ or multiple instances. In
+fact, this is exactly how `transifex.api` has been set up:
+
+```python
+# src/transifex.api/__init__.py
+
+from transifex.api.jsonapi import JsonApi, Resource
+
+class TransifexApi(JsonApi):
+    HOST = "https://rest.api.transifex.com"
+
+@TransifexApi.register
+class Organization(Resource):
+    TYPE = "organizations"
+
+transifex_api = TransifexApi()
+```
+
+```python
+# app.py (uses the global API connection instance)
+
+from transifex.api import transifex_api
+
+transifex_api.setup(auth="<API_TOKEN>")
+organization = transifex_api.Organization.get("1")
+
+```
+
+```python
+# app.py (uses multiple custom API connection instances)
+
+from transifex.api import TransifexApi
+
+api_1 = TransifexApi(auth="<API_TOKEN_1>")
+api_2 = TransifexApi(auth="<API_TOKEN_2>")
+
+organization_1 = api_1.Organization.get("1")
+organization_2 = api_2.Organization.get("2")
+```
+
+_(The whole logic behind this initialization process is further explained
+[here](https://www.kbairak.net/programming/python/2020/09/16/global-singleton-vs-instance-for-libraries.html))_
+
+#### Authentication
+
+The `auth` argument to `JsonApi` or `setup` can either be:
+
+1. A string, in which case all requests to the API server will include the
+   `Authorization: Bearer <API_TOKEN>` header
+2. A callable, in which case the return value is expected to be a dictionary
+   which will be merged with the headers of all requests to the API server
+
+   ```python
+   import datetime
+
+   from family_api import FamilyApi
+   from .secrets import KEY
+   from .crypto import sign
+
+   def myauth():
+       return {'x-signature': sign(KEY, datetime.datetime.now())}
+
+   family_api = FamilyApi(auth=myauth)
+   ```
+
+#### Custom headers
+
+You can supply custom HTTP headers to be sent with every request to the remote
+server using the `headers` keyword argument to the `JsonApi` constructor or the
+`setup` method.
+
+```python
+from family_api import FamilyApi
+family_api = FamilyApi(..., headers={'X-Application': "My-client"})
+```
+
+### Retrieval
+
+#### URLs
+
+By default, collection URLs have the form `/<type>` (eg `/children`) and item
+URLs have the form `/<type>/<id>` (eg `/children/1`). This is also part of
+{json:api}'s recommendations. If you want to customize them, you need to
+override the `get_collection_url` classmethod and the `get_item_url()` method
+of the resource's subclass:
+
+```python
+@FamilyApi.register
+class Child(Resource):
+    TYPE = "children"
+
+    @classmethod
+    def get_collection_url(cls):
+        return "/children_collection"
+
+    def get_item_url(self):
+        return f"/child_item/{self.id}"
+```
+
+
+#### Getting a single resource object from the API
+
+If you know the ID of the resource object, you can fetch its {json:api}
+representation with:
+
+```python
+child = family_api.Child.get("1")
+```
+
+The attributes of a resource object are `id`, `attributes`, `relationships`,
+`links` and `related`. `id`, `attributes`, `relationships` and `links` have
+exactly the same value as in the API response.
+
+```python
+parent = family_api.Parent.get("1")
+parent.id
+# "1"
+parent.attributes
+# {'name': "Zeus"}
+parent.relationships
+# {'children': {'links': {'self': "/parent/1/relationships/children",
+#                         'related': "/children?filter[parent]=1"}}}
+
+child = family_api.Child.get("1")
+child.id
+# "1"
+child.attributes
+# {'name': "Hercules"}
+child.relationships
+# {'parent': {'data': {'type': "parents", 'id': "1"},
+#             'links': {'self': "/children/1/relationships/parent",
+#                       'related': "/parents/1"}}}
+```
+
+You can reload an object from the server by calling `.reload()`:
+
+```python
+child.reload()
+# equivalent to
+child = family_api.Child.get(child.id)
+```
+
+#### Relationships
+
+##### Intro
+
+We need to talk a bit about how {json:api} represents relationships and how the
+`transifex.api.jsonapi` library interprets them. Depending on the value of a
+field of `relationships`, we consider the following possibilities. A
+relationship can either be:
+
+1. A **null** relationship which will be represented by a null value:
+
+   ```python
+   {'type': "children",
+    'id': "...",
+    'attributes': { ... },
+    'relationships': {
+        'parent': null,  # <---
+        ...,
+    },
+    'links': { ... }}
+   ```
+
+2. A **singular** relationship which will be represented by an object with both
+   `data` and `links` fields, with the `data` field being a dictionary:
+
+   ```python
+   {'type': "children",
+    'id': "...",
+    'attributes': { ... },
+    'relationships': {
+        'parent': {'data': {'type': "parents", 'id': "..."},     # <---
+                   'links': {'self': "...", 'related': "..."}},  # <---
+        ... ,
+    },
+    'links': { ... }}
+   ```
+
+3. A **plural** relationship which will be represented by an object with a
+   `links` field and either a missing `data` field or a `data` field which is a
+   list:
+
+   ```python
+   {'type': "parents",
+    'id': "...",
+    'attributes': { ... },
+    'relationships': {
+        'children': {'links': {'self': "...", 'related': "..."}},  # <---
+        ...,
+    },
+    'links': { ... }}
+   ```
+
+   or
+
+   ```python
+   {'type': "parents",
+    'id': "...",
+    'attributes': { ... },
+    'relationships': {
+        'children': {'links': {'self': "...", 'related': "..."},    # <---
+                     'data': [{'type': "children", 'id': "..."},    # <---
+                              {'type': "children", 'id': "..."},    # <---
+                              ... ]},                               # <---
+        ... ,
+    },
+    'links': { ... }}
+   ```
+
+This is important because `transifex.api.jsonapi` will make assumptions about
+the nature of relationships based on the existence of these fields.
+
+##### Fetching relationships
+
+The `related` field is meant to host the data of the relationships, **after**
+these have been fetched from the API. Lets revisit the last example and inspect
+the `relationships` and `related` fields:
+
+```python
+parent = family_api.Parent.get("1")
+parent.relationships
+# {'children': {'links': {'self': "/parent/1/relationships/children",
+#                         'related': "/children?filter[parent]=1"}}}
+parent.related
+# {}
+
+child = family_api.Child.get("1")
+child.relationships
+# {'parent': {'data': {'type': "parents", 'id': "1"},
+#             'links': {'self': "/children/1/relationships/parent",
+#                       'related': "/parents/1"}}}
+child.related
+# {parent: <Parent: 1 (Unfetched)>}
+```
+
+As you can see, the _parent→children_ `related` field is empty while the
+_child→parent_ `related` field is prefilled with an "unfetched" Parent
+instance. This happens becaue the first one is a _plural_ relationship while
+the second is a _singular_ relationship. Unfetched means that we only know its
+`id` so far. In both cases, we don't know any meaningful data about the
+relationships yet.
+
+In order to fetch the related data, you need to call `.fetch()` with the names
+of the relationships you want to fetch:
+
+```python
+child.related
+# {'parent': <Parent: 1 (Unfetched)>}
+(child.related['parent'].id,
+ child.related['parent'].attributes,
+ child.related['parent'].relationships)
+# ("1", {}, {})
+
+child.fetch('parent')  # Now `related['parent']` has all the information
+child.related
+# {parent: <Parent: 1>}
+(child.related['parent'].id,
+ child.related['parent'].attributes,
+ child.related['parent'].relationships)
+# ("1",
+#  {'name': "Zeus"},
+#  {'children': {'links': {'self': "/parent/1/relationships/children",
+#                          'related': "/children?filter[parent]=1"}}})
+
+parent.fetch('children')
+parent.related
+# {'children': [<Child: 1>, <Child: 2>]}
+(parent.related['children'][0].id,
+ parent.related['children'][0].attributes,
+ parent.related['children'][0].relationships)
+# ("1",
+#  {'name': "Hercules"},
+#  {'parent': {'data': {'type': "parents", 'id': "1"},
+#              'links': {'self': "/children/1/relationships/parent",
+#                        '/parents/1'}}})
+```
+
+Trying to fetch an already-fetched relationship will not actually trigger
+another request, unless you pass `force=True` to `.fetch()`.
+
+If `.fetch()` is only provided with one positional argument, it will return the
+relation:
+
+```python
+parent = family_api.Parent.get("1")
+
+print(parent.fetch('children')[1].name)
+# "Hercules"
+
+# Is equivalent to:
+
+parent.fetch('children')
+print(parent.related['children'][1].name)
+```
+
+#### Shortcuts
+
+You can access all keys in `attributes` and `related` directly on the resource
+object:
+
+```python
+child.name == child.attributes['name'] == "Hercules"
+# True
+```
+
+This is very handy, both for reading and setting values to those fields,
+however you should be careful when setting them. If the key is not already part
+of `attributes` or `relationships`, the assignment will fall back to the
+default operation of Python objects, which is to add the key to the `__dict__`
+attribute:
+
+```python
+child.__dict__
+# {'id': ..., 'attributes': {'name': "Hercules"}, ...}
+
+child.name = "Achilles"
+child.__dict__
+# {'id': ..., 'attributes': {'name': "Achilles"}, ...}
+#                                    ^^^^^^^^^^
+
+child.hair_color = "red"
+child.__dict__
+# {'id': ..., 'attributes': {'name': "Achilles"}, 'hair_color': "red", ...}
+#                                                 ^^^^^^^^^^^^^^^^^^^
+```
+
+Be careful of this because the new keys will not be included in subsequent
+PATCH operations to update the resource on the server. Normally you won't have
+to worry about this since the API server will likely have provided all
+attributes and relationships it is likely to accept in subsequent requests,
+even if their value is set to `null`. If you definitely want to add a new field
+to an object's `attributes` or `relationships`, you can always fall back to
+doing so directly:
+
+```python
+child.attributes['hair_color'] = "red"
+child.__dict__
+# {'id': ..., 'attributes': {'name': "Hercules", 'hair_color': "red"}, ...}
+#                                                ^^^^^^^^^^^^^^^^^^^
+```
+
+#### Getting Resource collections
+
+You can access a collection of resource objects using one of the `list`,
+`filter`, `page`, `include`,`sort`, `fields`, `extra`, `all` and `all_pages`
+classmethods of Resource subclass.
+
+```python
+children = family_api.Child.list()
+# [<Child: 1>, <Child: 2>, ...]
+```
+
+Each method does the following:
+
+- `list` returns the first page of the results
+
+- `filter` applies filters; nested filters are separated by double underscores
+  (`__`), Django-style
+
+  | operation         | GET request       |
+  |-------------------|-------------------|
+  | `.filter(a=1)`    | `?filter[a]=1`    |
+  | `.filter(a__b=1)` | `?filter[a][b]=1` |
+
+  _Note: because it's a common use-case, using a resource object as the value
+  of a filter operation will result in using its `id` field_
+
+  ```python
+  parent = family_api.Parent.get("1")
+
+  family_api.Child.filter(parent=parent)
+  # is equivalent to
+  family_api.Child.filter(parent=parent.id)
+  ```
+
+- `page` applies pagination; it accepts either one positional argument which
+  will be passed to the `page` GET parameter or multiple keyword arguments
+  which will be passed as nested `page` GET parameters
+
+  | operation         | GET request            |
+  |-------------------|------------------------|
+  | `.page(1)`        | `?page=1`              |
+  | `.page(a=1, b=2)` | `?page[a]=1&page[b]=2` |
+
+  (_Note: you will probably not have to use `.page` yourself since the returned
+  lists support pagination on their own, see below_)
+
+- `include` will set the `include` GET parameter; it accepts multiple
+  positional arguments which it will join with commas (`,`)
+
+  | operation                   | GET request           |
+  |-----------------------------|-----------------------|
+  | `.include('parent', 'pet')` | `?include=parent,pet` |
+
+- `sort` will set the `sort` GET parameter; it accepts multiple positional
+  arguments which it will join with commas (`,`)
+
+  | operation              | GET request      |
+  |------------------------|------------------|
+  | `.sort('age', 'name')` | `?sort=age,name` |
+
+- `fields` will set the `fields` GET parameter; it accepts multiple positional
+  arguments which it will join with commas (`,`)
+
+  | operation                | GET request        |
+  |--------------------------|--------------------|
+  | `.fields('age', 'name')` | `?fields=age,name` |
+
+- `extra` accepts any keyword arguments which will be added to the GET
+  parameters sent to the API
+
+  | operation                | GET request     |
+  |--------------------------|-----------------|
+  | `.extra(group_by="age")` | `?group_by=age` |
+
+- `all` returns a generator that will yield all results of a paginated
+  collection, using multiple requests if necessary; the pages are fetched
+  on-demand, so if you abort the generator early, you will not be performing
+  requests against every possible page
+
+- `all_pages` returns a generator of non-empty pages; similarly to `all`, pages
+  are fetched on-demand (in fact, `all` uses `all_pages` internally)
+
+All the above methods can be chained to each other. So:
+
+```python
+family_api.Child.list().filter(a=1)
+# is equivalent to
+family_api.Child.filter(a=1)
+
+family_api.Child.filter(a=1).filter(b=2)
+# is equivalent to
+family_api.Child.filter(a=1, b=2)
+
+family_api.Child.list().all()
+# is equivalent to
+family_api.Child.all()
+```
+
+The collections are also lazy (Django-style). You will not actually make any
+requests to the server until you try to access a collection like a list. So
+this:
+
+```python
+def get_children(gender=None, hair_color=None):
+    result = family_api.Child.list()
+    if gender is not None:
+        result = result.filter(gender=gender)
+    if hair_color is not None:
+        result = result.filter(hair_color=hair_color)
+    return result
+
+print([child.name for child in get_children(hair_color="red")])
+```
+
+will only make one request to the server during the execution of the list
+comprehension in the last line.
+
+You can also access pagination via the `has_next`, `has_previous`, `next` and
+`previous` methods of a returned list (which is what `all_pages` and `all` use
+internally).
+
+All the previous methods also work on plural relationships (assuming the API
+supports the applied filters etc on the endpoint specified by the `related`
+link of the relationship).
+
+```python
+
+print(parent.fetch('children').filter(name="Hercules")[0].name)
+
+# Will print the names of the *first page* of the children
+print([child.name for child in parent.children])
+# Will print the names of the *all* the children
+print([child.name for child in parent.children.all()])
+```
+
+#### Prefetching relationships with `include`
+
+If you use the `include` method on a collection retrieval or if you use the
+`include` keyword argument on `.get()` (and if the server supports it), the
+included values of the response will be used to prefill the relevant fields of
+`related`:
+
+```python
+child = family_api.Child.get("1", include=['parent'])
+child.parent.name  # No need to fetch the parent
+# "Zeus"
+
+children = family_api.Child.list().include('parent')
+[child.parent.name for child in children]  # No need to fetch the parents
+# ["Zeus", "Zeus", ...]
+```
+
+In case of a plural relationships with a list `data` field, if the response
+supplies the related items in the `included` section, these too will be
+prefilled.
+
+```python
+parent = family_api.Parent.get("1", include=['children'])
+
+# Assuming the response looks like:
+# {'data': {'type': "parents",
+#           'id': "1",
+#           'attributes': ...,
+#           'relationships': {'children': {'data': [{'type': "children", 'id': "1"},
+#                                                   {'type': "children", 'id': "2"}],
+#                                          'links': ...}}},
+#  'included': [{'type': "children",
+#                'id': "1",
+#                'attributes': {'name': "Hercules"}},
+#               {'type': "children",
+#                'id': "2",
+#                'attributes': {'name': "Achilles"}}]}
+
+[child.name for child in parent.children]  # No need to fetch
+# ["Hercules", "Achilles"]
+```
+
+#### Getting single resource objects using filters
+
+Appending `.get()` to a collection will ensure that the collection is of size 1
+and return the one resource instance in it. If the collection's size isn't 1,
+it will raise a `transifex.api.jsonapi.DoesNotExist` or
+`transifex.api.jsonapi.MultipleObjectsReturned` exception accordingly (both are
+subclasses of `transifex.api.jsonapi.NotSingleItem`).
+
+```python
+child = family_api.Child.filter(name="Bill").get()
+```
+
+The `Resource`'s `.get()` classmethod, which we covered before, also accepts
+keyword arguments, if a positional `id` argument isn't used. Calling it this
+way, will apply the filters and use the collection's `.get()` method on the
+result.
+
+```python
+child = family_api.Child.get(name="Bill")
+# is equivalent to
+child = family_api.Child.filter(name="Bill").get()
+```
+
+_Note: The `Resource`'s `.get()` classmethod accepts an `include` keyword
+argument as well, so be careful of naming conflicts if you want to use a filter
+called 'include'_
+
+```python
+# Don't do this
+family_api.Child.get(name="Bill", include="parent")
+# equivalent to
+family_api.Child.filter(name="Bill").include('parent').get()
+
+# Do this instead
+child = family_api.Child.filter(name="Bill", include="parent").get()
+```
+
+### Editing
+
+#### Saving changes
+
+After you change some attributes or relationships, you can call `.save()` on an
+object, which will trigger a PATCH request to the server. Because usually the
+server includes immutable fields with the response (creation timestamps etc),
+you don't want to include all attributes and relationships in the request. You
+can specify which fields will be sent with:
+
+- `.save()`'s positional arguments, or
+- the `EDITABLE` class attribute of the Resource subclass
+
+```python
+child = family_api.Child.get("1")
+child.name += " the Great"
+child.save('name')
+
+# or
+
+@FamilyApi.register
+class Child(Resource):
+    TYPE = "children"
+    EDITABLE = ['name']
+
+child = family_api.Child.get("1")
+child.name += " the Great"
+child.save()
+```
+
+Because setting values right before saving is a common use-case, `.save()` also
+accepts keyword arguments. These will be set on the resource object, right
+before the actual saving:
+
+```python
+child.save(name="Hercules")
+# is equivalent to
+child.name = "Hercules"
+child.save('name')
+```
+
+#### Creating new resources
+
+Calling `.save()` on an object whose `id` is not set will result in a POST
+request which will (attempt to) create the resource on the server.
+
+```python
+parent = family_api.Parent.get("1")
+child = family_api.Child(attributes={'name': "Hercules"},
+              relationships={'parent': parent})
+child.save()
+```
+
+After saving, the object will have the `id` returned by the server, plus any
+other server-generated attributes and relationships (for example, creation
+timestamps).
+
+There is a shortcut for the above, called `.create()`
+
+```python
+parent = family_api.Parent.get("1")
+child = family_api.Child.create(attributes={'name': "Hercules"},
+                     relationships={'parent': parent})
+```
+
+_Note: for relationships, you can provide either a resource instance, a
+"Resource Identifier" (the 'data' value of a relationship object) or an entire
+relationship from another resource. So, the following are equivalent:_
+
+```python
+# Well, almost equivalent, the first example will trigger a request to fetch
+# the parent's data from the server
+child = family_api.Child.create(attributes={'name': "Hercules"},
+                                relationships={'parent': family_api.Parent.get("1")})
+child = family_api.Child.create(attributes={'name': "Hercules"},
+                                relationships={'parent': family_api.Parent(id="1")})
+child = family_api.Child.create(attributes={'name': "Hercules"},
+                                relationships={'parent': {'type': "parents": 'id': "1"}})
+child = family_api.Child.create(attributes={'name': "Hercules"},
+                                relationships={'parent': {'data': {'type': "parents": 'id': "1"}}})
+```
+
+
+This way, you can reuse a relationship from another object when creating,
+without having to fetch the relationship:
+
+```python
+new_child = family_api.Child.create(attributes={'name': "Achilles"},
+                                    relationships={'parent': old_child.parent})
+```
+
+##### Magic kwargs
+
+When making new (unsaved) instances, or when you create instances on the server
+with `.create()`, you can supply any keyword argument apart from `id`,
+`attributes`, `relationships`, etc and they will be interpreted as attributes
+or relationships. Anything that looks like a relationship will be interpreted
+as such while everything else will be interpreted as an attribute.
+
+Things that are interpreted as relationships are:
+
+- Resource instances
+- Resource identifiers - dictionaries with 'type' and 'id' fields
+- Relationship objects - dictionaries with a single 'data' field whose value is
+  a resource identifier
+
+So
+
+```python
+family_api.Child(name="Hercules")
+# is equivalent to
+family_api.Child(attributes={'name': "Hercules"})
+
+family_api.Child(parent={'type': "parents", 'id': "1"})
+# is equivalent to
+family_api.Child(relationships={'parent': {'type': "parents", 'id': "1"}})
+
+family_api.Child(parent=family_api.Parent(id="1"))
+# is equivalent to
+family_api.Child(relationships={'parent': family_api.Parent(id="1")})
+```
+
+If you are worried about naming conflicts, for example if you want to have a
+relationship called 'attributes', an attribute that looks like a relationship
+and an attribute called 'id', you should fall back to using 'attributes' and
+'relationships' directly.
+
+```python
+# Don't do this
+child = family_api.Child(attributes={'type': "attributes", 'id': "1"},
+                         stats={'type': "stats", 'id': "2"},
+                         id="3")
+child.to_dict()
+# {'type': "children",
+#  'attributes': {'type': "attributes", 'id': "1"},
+#  'relationships': {'stats': {'data': {'type': "stats", 'id': "2"}}},
+#  'id': "3"}
+
+# Do this instead
+child = family_api.Child(relationships={'attributes': {'type': "attributes", 'id': "1"}}
+                         attributes={'stats': {'type': "stats", 'id': "2"}, 'id': "3"})
+child.to_dict()
+# {'type': "children",
+#  'attributes': {'stats': {'type': "stats", 'id': "2"},
+#                 'id': "3"},
+#  'relationships': {'attributes': {'data': {'type': "attributes", 'id': "1"}}}}
+```
+
+_Note: `.to_dict()` returns the {json:api} representation of the Resource
+instance, ie what the payload to the server would be if we called `.save()` on
+it_
+
+##### Client-generated IDs
+
+Since `.save()` will issue a PATCH request when invoked on objects that have an
+ID, if you want to supply your own client-generated ID during creation, you
+**have** to use `.create()`, which will always issue a POST request.
+
+```python
+family_api.Child(attributes={'name': "Hercules"}).save()
+# POST: {data: {type: "children", attributes: {name: "Hercules"}}}
+
+family_api.Child(id="1", attributes={'name': "Hercules"}).save()
+# PATCH: {data: {type: "children", id: "1", attributes: {name: "Hercules"}}}
+
+family_api.Child.create(attributes={'name': "Hercules"})
+# POST: {data: {type: "children", attributes: {name: "Hercules"}}}
+
+family_api.Child.create(id="1", attributes={'name': "Hercules"})
+# POST: {data: {type: "children", id: "1", attributes: {name: "Hercules"}}}
+# ^^^^
+```
+
+
+#### Deleting
+
+Deleting happens simply by calling `.delete()` on an object. After deletion,
+the object will have the same data as before, except its `id` will be set to
+`None`. This happens in case you want to delete an object and instantly
+re-create it, with a different ID.
+
+```python
+child = family_api.Child.get("1")
+child.delete()
+
+# Will create a new child with the same name and parent as the previous one
+child.save('name', 'parent')
+
+child.id in (None, "1")
+# False
+```
+
+#### Editing relationships
+
+##### Singular relationships
+
+Changing a singular relationship can happen in two ways (this also depends on
+what the server supports).
+
+```python
+child = family_api.Child.get("1")
+
+child.parent = new_parent
+child.save('parent')
+
+# or
+
+child.change('parent', new_parent)
+```
+
+The first one will send a PATCH request to `/children/1` with a body of:
+
+```json
+{"data": {"type": "children",
+          "id": "1",
+          "relationships": {"parent": {"data": {"type": "parents", "id": "2"}}}}}
+```
+
+The second one will send a PATCH request to the URL indicated by
+`child.relationships['parent']['links']['self']`, which will most likely be
+something like `/children/1/relationships/parent`, with a body of:
+
+```json
+{"data": {"type": "parents", "id": "2"}}
+```
+
+If you want to use the first way, you could also change the relationship
+directly:
+
+```python
+child.relationships['parent'] = {'data': {'type': "parents", 'id': "2"}}
+
+child.save('parent')
+```
+
+However, this poses a danger. `relationships` and `related` are supposed to be
+in sync with each other and, if you change one or the other directly, they may
+stop being in sync which may generate some confusion later. A successful
+`.save()` will rewrite the relationships so you should be OK. However, if you
+want to be safe, you should use the `.set_related()` method to edit
+relationships:
+
+```python
+child.set_related('parent', family_api.Parent(id="2"))
+```
+
+or use the relationship's name shortcut:
+
+```python
+child.parent = family_api.Parent(id="2")
+```
+
+(the shortcut uses `.set_related()` during assignment internally anyway)
+
+##### Plural relationships
+
+For changing plural relationships, you can use one of the `add`, `remove` and
+`reset` methods:
+
+```python
+parent = family_api.Parent.get("1")
+parent.add('children', [new_child, ...])
+parent.remove('children', [existing_child, ...])
+parent.reset('children', [child_a, child_b, ...])
+```
+
+These will send a POST, DELETE or PATCH request respectively to the URL
+indicated by `parent.relationships['children']['links']['self']`, which will
+most likely be something like `/parents/1/relationships/children`, with a body
+of:
+
+```json
+{"data": [{"type": "children", "id": "1"},
+          {"type": "children", "id": "2"},
+          {"...": "..."}]}
+```
+
+Similar to the case when we were instantiating objects with relationships, the
+values passed to the above methods can either be resource objects, "resource
+identifiers" or entire relationship objects:
+
+```python
+parent.add('children', [family_api.Child.get("1"),
+                        family_api.Child(id="2"),
+                        {'type': "children", 'id': "3"},
+                        {'data': {'type': "children", 'id': "4"}}])
+```
+
+This way, you can easily use another object's plural relationship:
+
+```python
+parent_a = family_api.Parent.get('1')
+parent_b = family_api.Parent.get('2')
+
+# Make sure 'parent_b' has the same children as 'parent_a'
+parent_b.reset('children', list(parent_a.fetch('children').all()))
+```
+
+#### Bulk operations
+
+Resource subclasses provide the `bulk_delete`, `bulk_create` and `bulk_update`
+classmethods for API endpoints that support such operations. The arguments to
+these class methods are quite flexible. Consult the docstrings of each method
+for their types or see the following examples.
+
+Furthermore, `bulk_update` accepts a `fields` keyword argument with the
+`attributes` and `relationships` of the objects it will attempt to update.
+
+```python
+# Bulk-create
+family_api.Child.bulk_create([
+   family_api.Child(attributes={'name': "One"}, relationships={'parent': parent}),
+   {'attributes': {'name': "Two"}, 'relationships': {'parent': parent}},
+   ({'name': "Three"}, {'parent': parent}),
+])
+
+# Bulk-update
+child_a = family_api.Child.get("a")
+child_a.married = True
+
+family_api.Child.bulk_update(
+   [child_a,
+    {'id': "b", 'attributes': {'married': True}},
+    ("c", {'married': True}), "d"],
+   fields=['married'],
+)
+
+# Bulk delete
+child_a = family_api.Child.get("a")
+family_api.Child.bulk_delete([child_a, {'id': "b"}, "c"])
+
+parent = family_api.Parent.get("1")
+family_api.Child.delete(list(parent.children.all()))
+```
+
+For more details, see our
+[bulk oprations {json:api} profile](https://github.com/transifex/openapi/blob/devel/txapi_spec/bulk_profile.md).
+
+#### Form uploads, redirects
+
+If an endpoint accepts other content-types apart from
+`application/vnd.api+json` during creation (most likely a `multipart/form-data`
+for file uploads), you can perform such requests using the `.create_with_form`
+classmethod. The keyword arguments you provide will be passed to the `requests`
+library, giving you complete control over the request you want to perform.
+
+According to {json:api}'s recommendations, an endpoint may return a
+303-redirect response. If that's the case for a `.get()` or `.reload()` call,
+the object's `id`, `attributes`, `links`, `relationships` and `related`
+attributes will be empty. What will be there is a `redirect` attribute set to
+the response's `Location` header's value. Calling `.follow()` on such an object
+will retrieve that location and process the response using the appropriate
+class.
+
+Given these two mechanisms, here is how you might go about performing a
+[source file upload](https://transifex.github.io/openapi/#tag/Resource-Strings/paths/~1resource_strings_async_uploads/post)
+in Transifex API:
+
+```python
+@TransifexApi.register
+class TxResource(Resource)
+    TYPE = "resources"
+
+@TransifexApi.register
+class ResourceStringsAsyncUpload(Resource)
+    TYPE = "resource_strings_async_uploads"
+
+@TransifexApi.register
+class ResourceString(Resource)
+    TYPE = "resource_strings"
+
+transifex_api = TransifexApi(...)
+
+resource = transifex_api.TxResource.get(...)
+with open(...) as f:
+    upload = transifex_api.ResourceStringsAsyncUpload.create_with_form(
+        data={'resource': resource.id},
+        files={'content': f},
+    )
+while True:
+    if upload.redirect:
+        strings = upload.follow()
+        break
+    sleep(5)
+    upload.reload()
+```
+
+## `transifex.api` usage
+
+As we said before, the `transifex.api` package has minimal code as almost the
+entire functionality is implemented in `transifex.api.jsonapi`. `transifex.api`
+simply hosts the Resource subclasses. You can find them
+[here](transifex/api/__init__.py)
+and cross-check with the
+[API specification](https://transifex.github.io/openapi/). Assuming you
+understand how the `transifex.api.jsonapi` package works, you should be able to
+work with `transifex.api`.
+
+Sample usage:
+
+```python
+import os
+from transifex.api import transifex_api
+
+# There is a default host for transifex
+transifex_api.setup(auth=os.environ['API_TOKEN'])
+
+organizations = {organization.slug: organization
+                 for organization in transifex_api.Organization.all()}
+organization = organizations['kb_org']
+
+project = transifex_api.Project.get(organization=organization, slug="kb1")
+
+resource = Resource.get(project=project, slug="fileless")
+
+languages = {language.code: language
+             for language in project.fetch('languages').all()}
+language = languages['el']
+
+translations = transifex_api.ResourceTranslation.\
+    filter(resource=resource, language=language).\
+    include('resource_string')
+translation = translations[0]
+
+# Let's translate something
+if not translation.strings:
+    source_string = translation.resource_string.strings['other']
+    translation.strings = {'other': source_string + " in greeeek!!!"}
+if not translation.reviewed:
+    translation.reviewed = True
+translation.save('strings', 'reviewed')
+```
+
+
+## Testing
+
+To run the tests:
+
+```sh
+mkvirtualenv transifex_sdk
+pip install -e .
+pip install -r requirements/testing.txt
+make test
+```
+
+There are several variations on test commands, most targeted towards active
+development:
+
+
+- `make test`: Run tests in multiple python versions using
+  [tox](https://tox.readthedocs.io/en/latest/)
+- `make covtest`: Display coverage information using
+  [pytest-cov](https://github.com/pytest-dev/pytest-cov)
+- `make debugtest`: Disable screen capture (with `-s` option to pytest) so that
+  you can invoke a debugger while the tests are running
+- `make watchtest`: Invoke the tests with
+  [pytest-watch](https://github.com/joeyespo/pytest-watch) so that they rerun
+  every time a source python file in the repository changes

--- a/transifex/api/__init__.py
+++ b/transifex/api/__init__.py
@@ -1,0 +1,184 @@
+import time
+
+from .jsonapi import JsonApi
+from .jsonapi import Resource as JsonApiResource
+from .jsonapi.exceptions import JsonApiException
+
+
+class TransifexApi(JsonApi):
+    HOST = "https://rest.api.transifex.com"
+
+
+@TransifexApi.register
+class Organization(JsonApiResource):
+    TYPE = "organizations"
+
+
+@TransifexApi.register
+class Team(JsonApiResource):
+    TYPE = "teams"
+
+
+@TransifexApi.register
+class Project(JsonApiResource):
+    TYPE = "projects"
+
+
+@TransifexApi.register
+class Language(JsonApiResource):
+    TYPE = "languages"
+
+
+@TransifexApi.register
+class Resource(JsonApiResource):
+    TYPE = "resources"
+
+    def purge(self):
+        count = 0
+        # Instead of filter, if Resource had a plural relationship to
+        # ResourceString, we could do `self.fetch('resource_strings')`
+        for page in list(self.API.ResourceString.
+                         filter(resource=self).
+                         all_pages()):
+            count += len(page)
+            self.API.ResourceString.bulk_delete(page)
+        return count
+
+
+@TransifexApi.register
+class ResourceString(JsonApiResource):
+    TYPE = "resource_strings"
+
+
+@TransifexApi.register
+class ResourceTranslation(JsonApiResource):
+    TYPE = "resource_translations"
+    EDITABLE = ["strings", 'reviewed', "proofread"]
+
+
+@TransifexApi.register
+class ResourceStringsAsyncUpload(JsonApiResource):
+    TYPE = "resource_strings_async_uploads"
+
+    @classmethod
+    def upload(cls, resource, content, interval=5):
+        """ Upload source content with multipart/form-data.
+
+            :param resource: A (transifex) Resource instance or ID
+            :param content: A string or file-like object
+            :param interval: How often (in seconds) to poll for the completion
+                             of the upload job
+        """
+
+        if isinstance(resource, JsonApiResource):
+            resource = resource.id
+
+        upload = cls.create_with_form(data={'resource': resource},
+                                      files={'content': content})
+
+        while True:
+            if hasattr(upload, 'errors') and len(upload.errors) > 0:
+                errors = [{
+                    'code': e['code'],
+                    'detail': e['detail'],
+                    'title': e['detail'],
+                    'status': '409'} for e in upload.errors]
+                raise JsonApiException(409, errors)
+
+            if upload.redirect:
+                return upload.follow()
+            if (hasattr(upload, 'attributes')
+                    and upload.attributes.get("details")):
+                return upload.attributes.get("details")
+
+            time.sleep(interval)
+            upload.reload()
+
+
+@TransifexApi.register
+class ResourceTranslationsAsyncUpload(JsonApiResource):
+    TYPE = "resource_translations_async_uploads"
+
+    @classmethod
+    def upload(cls, resource, content, language, interval=5,
+               file_type='default'):
+        """ Upload translation content with multipart/form-data.
+
+            :param resource: A (transifex) Resource instance or ID
+            :param content: A string or file-like object
+            :param language: A (transifex) Language instance or ID
+            :param interval: How often (in seconds) to poll for the completion
+                             of the upload job
+            :param file_type: The content file type
+        """
+
+        if isinstance(resource, JsonApiResource):
+            resource = resource.id
+
+        upload = cls.create_with_form(data={'resource': resource,
+                                            'language': language,
+                                            'file_type': file_type},
+                                      files={'content': content})
+
+        while True:
+            if hasattr(upload, 'errors') and len(upload.errors) > 0:
+                errors = [{
+                    'code': e['code'],
+                    'detail': e['detail'],
+                    'title': e['detail'],
+                    'status': '409'} for e in upload.errors]
+                raise JsonApiException(409, errors)
+
+            if upload.redirect:
+                return upload.follow()
+            if (hasattr(upload, 'attributes')
+                    and upload.attributes.get("details")):
+                return upload.attributes.get("details")
+
+            time.sleep(interval)
+            upload.reload()
+
+
+@TransifexApi.register
+class User(JsonApiResource):
+    TYPE = "users"
+
+
+@TransifexApi.register
+class TeamMembership(JsonApiResource):
+    TYPE = "team_memberships"
+
+
+@TransifexApi.register
+class ResourceLanguageStats(JsonApiResource):
+    TYPE = "resource_language_stats"
+
+
+@TransifexApi.register
+class ResourceTranslationsAsyncDownload(JsonApiResource):
+    TYPE = "resource_translations_async_downloads"
+
+    @classmethod
+    def download(cls, interval=5, *args, **kwargs):
+        download = cls.create(*args, **kwargs)
+        while True:
+            if hasattr(download, 'errors') and len(download.errors) > 0:
+                errors = [{'code': e['code'],
+                           'detail': e['detail'],
+                           'title': e['detail'],
+                           'status': '409'}
+                          for e in download.errors]
+                raise JsonApiException(409, errors)
+            if download.redirect:
+                return download.redirect
+            time.sleep(interval)
+            download.reload()
+
+
+@TransifexApi.register
+class I18nFormat(JsonApiResource):
+    TYPE = "i18n_formats"
+
+
+# This is our global object
+transifex_api = TransifexApi()

--- a/transifex/api/__init__.py
+++ b/transifex/api/__init__.py
@@ -1,6 +1,7 @@
 import time
 
 import transifex
+
 from .jsonapi import JsonApi
 from .jsonapi import Resource as JsonApiResource
 from .jsonapi.exceptions import JsonApiException

--- a/transifex/api/__init__.py
+++ b/transifex/api/__init__.py
@@ -1,5 +1,6 @@
 import time
 
+import transifex
 from .jsonapi import JsonApi
 from .jsonapi import Resource as JsonApiResource
 from .jsonapi.exceptions import JsonApiException
@@ -31,6 +32,9 @@ class DownloadMixin(object):
 
 class TransifexApi(JsonApi):
     HOST = "https://rest.api.transifex.com"
+    HEADERS = {
+        'User-Agent': "Transifex-API-SDK/{}".format(transifex.__version__),
+    }
 
 
 @TransifexApi.register

--- a/transifex/api/jsonapi/__init__.py
+++ b/transifex/api/jsonapi/__init__.py
@@ -1,0 +1,4 @@
+from .apis import JsonApi  # noqa
+from .exceptions import (DoesNotExist, JsonApiException,  # noqa
+                         MultipleObjectsReturned, NotSingleItem)
+from .resources import Resource  # noqa

--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
+from copy import deepcopy
+
 import requests
 import six
-from copy import deepcopy
 
 from .auth import BearerAuthentication
 from .compat import JSONDecodeError

--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import requests
 import six
+from copy import deepcopy
 
 from .auth import BearerAuthentication
 from .compat import JSONDecodeError
@@ -90,6 +91,7 @@ class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
     """
 
     HOST = None
+    HEADERS = None
 
     def __init__(self, **kwargs):
         """ Create a new API connection instance. It will use the class's
@@ -113,7 +115,10 @@ class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
             self.class_registry[base_class.__name__] = child_class
 
         self.host = self.HOST
-        self.headers = {}
+        if self.HEADERS is None:
+            self.headers = {}
+        else:
+            self.headers = deepcopy(self.HEADERS)
         self.setup(**kwargs)
 
     def setup(self, host=None, auth=None, headers=None):
@@ -127,7 +132,7 @@ class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
                 self.make_auth_headers = BearerAuthentication(auth)
 
         if headers is not None:
-            self.headers = headers
+            self.headers.update(headers)
 
     @classmethod
     def register(cls, klass):

--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -1,0 +1,256 @@
+from __future__ import absolute_import, unicode_literals
+
+import requests
+import six
+
+from .auth import BearerAuthentication
+from .compat import JSONDecodeError
+from .exceptions import JsonApiException
+from .resources import Resource
+
+
+type_ = type  # alias to avoid naming conflicts
+
+
+class _JsonApiMetaclass(type_):
+    """ Simple metaclass that overwrites the `registry` class variable on
+        `JsonApi` subclasses. This is so that if multiple API connection types
+        are defined on the same application, one won't "contaminate" the other.
+
+            eg
+
+            >>> class API_A(jsonapi.JsonApi):
+            ...     HOST = "..."
+
+            >>> @API_A.register
+            ... class ResourceA(jsonapi.Resource):
+            ...     TYPE = "resource_a"
+
+            >>> class API_AA(API_A):
+            ...     HOST = "..."
+
+            >>> @API_AA.register
+            ... class ResourceAA(jsonapi.Resource):
+            ...     TYPE = "resource_aa"
+
+            >>> class API_B(jsonapi.JsonApi):
+            ...     HOST = "..."
+
+            >>> @API_B.register
+            ... class ResourceB(jsonapi.Resource):
+            ...     TYPE = "resource_b"
+
+            >>> API_A.registry
+            <<< [ResourceA]
+
+            >>> API_AA.registry
+            <<< [ResourceA, ResourceAA]
+
+            >>> API_B.registry
+            <<< [ResourceB]
+    """
+
+    def __new__(cls, *args, **kwargs):
+        result = super(_JsonApiMetaclass, cls).__new__(cls, *args, **kwargs)
+
+        # Use a copy, not reference to parent's registry
+        result.registry = list(getattr(result, 'registry', []))
+
+        return result
+
+
+class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
+    """ Inteface for a new {json:api} API connection. Initialization
+        parameters:
+
+        - host: The URL of the API
+        - headers: A dict of HTTP headers that will be included in every
+                   request to the server
+        - auth: The authentication method. Can either be:
+
+          1. A callable, whose return value should be a dictionary which will
+             be merged with the headers of all HTTP request sent to the API
+          2. A string, in which case the 'Authorization' header will be
+             `Bearer <auth>`
+
+            >>> class API(jsonapi.JsonApi):
+            ...     HOST = "..."
+            >>> api = API(host=..., auth=...)
+
+        The arguments are optional and can be edited later with `.setup()`
+
+            >>> api = API()
+            >>> api.setup(host=..., auth=...)
+
+        All Resource classes that use this API should be registered to this API
+        class:
+
+            >>> @API.register
+            ... class Foo(jsonapi.Resource):
+            ...     TYPE = "foos"
+    """
+
+    HOST = None
+
+    def __init__(self, **kwargs):
+        """ Create a new API connection instance. It will use the class's
+            registry to build the instance's registries in order to be able to
+            lookup API resource classes from their class names or API types.
+
+            Delegates configuration to `setup` method.
+        """
+
+        self.type_registry = {}
+        self.class_registry = {}
+
+        for base_class in self.__class__.registry:
+            # Dynamically create a subclass adding 'self' (the API connection
+            # instance) as a class variable to it
+            child_class = type_(base_class.__name__,
+                                (base_class, ),
+                                {'API': self})
+            # Lookup the new class by it's name or its TYPE class attribute
+            self.type_registry[base_class.TYPE] = child_class
+            self.class_registry[base_class.__name__] = child_class
+
+        self.host = self.HOST
+        self.headers = {}
+        self.setup(**kwargs)
+
+    def setup(self, host=None, auth=None, headers=None):
+        if host is not None:
+            self.host = host
+
+        if auth is not None:
+            if callable(auth):
+                self.make_auth_headers = auth
+            else:
+                self.make_auth_headers = BearerAuthentication(auth)
+
+        if headers is not None:
+            self.headers = headers
+
+    @classmethod
+    def register(cls, klass):
+        """ Register a API resource type with this API connection *type* (since
+            this is a classmethod). When a new API connection *instance* is
+            created (see `__init__`), it will use this to build its own
+            registry in order to identify class names or API types with the
+            relevant API resource classes.
+        """
+
+        cls.registry.append(klass)
+        return klass
+
+    def __getattr__(self, attr):
+        """ Access a registered API resource class. A class name or API
+            resource type can be used.
+
+                >>> class FooApi(JsonApi):
+                ...     HOST = "https://api.foo.com"
+
+                >>> @FooApi.register
+                ... class Foo(Resource):
+                ...     TYPE = "foos"
+
+                >>> foo_api = FooApi()
+
+                >>> foo_api.Foo.list()
+                >>> # or
+                >>> foo_api.foos.list()
+        """
+
+        try:
+            return self.class_registry[attr]
+        except KeyError:
+            try:
+                return self.type_registry[attr]
+            except KeyError:
+                raise AttributeError(attr)
+
+    #                 Required args
+    def request(self, method, url,
+                # Not passed to requests, used to determine Content-Type
+                bulk=False,
+                # Forwarded to requests
+                headers=None, data=None, files=None,
+                allow_redirects=False,
+                **kwargs):
+        if url.startswith('/'):
+            url = "{}{}".format(self.host, url)
+
+        if bulk:
+            content_type = 'application/vnd.api+json;profile="bulk"'
+        elif (data, files) == (None, None):
+            content_type = "application/vnd.api+json"
+        else:
+            # If data and/or files are set, requests will determine
+            # Content-Type on its own
+            content_type = None
+
+        actual_headers = dict(self.headers)
+
+        if headers is not None:
+            actual_headers.update(headers)
+        actual_headers.update(self.make_auth_headers())
+        if content_type is not None:
+            actual_headers.setdefault('Content-Type', content_type)
+
+        response = requests.request(method, url, headers=actual_headers,
+                                    data=data, files=files,
+                                    allow_redirects=allow_redirects,
+                                    **kwargs)
+
+        if not response.ok:
+            try:
+                exc = JsonApiException(response.status_code,
+                                       response.json()['errors'])
+            except Exception:
+                response.raise_for_status()
+            else:
+                raise exc
+        try:
+            return response.json()
+        except JSONDecodeError:
+            # Most likely empty response when deleting
+            return response
+
+    def new(self, data=None, type=None, **kwargs):
+        """ Return a new resource instance, using the appropriate Resource
+            subclass, provided that it has been registered with this API
+            instance.
+
+                >>> _api = jsonapi.JsonApi(...)
+                >>> @_api.register
+                ... class Foo(jsonapi.Resource):
+                ...     TYPE = "foos"
+                >>> obj = _api.new(type="foos", ...)
+
+                >>> isinstance(obj, Foo)
+                <<< True
+        """
+
+        if data is not None:
+            if 'data' in data:
+                data = data['data']
+            return self.new(**data)
+        else:
+            if type in self.type_registry:
+                klass = self.type_registry[type]
+            else:
+                # Lets make a new class on the fly
+                klass = type_(type.capitalize(),
+                              (Resource, ),
+                              {'API': self, 'TYPE': type})
+            return klass(**kwargs)
+
+    def as_resource(self, data):
+        """ Little convenience function when we don't know if we are dealing
+            with a Resource instance or a dict describing a relationship. Will
+            use the appropriate Resource subclass.
+        """
+
+        try:
+            return self.new(data)
+        except Exception:
+            return data

--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -8,7 +8,6 @@ from .compat import JSONDecodeError
 from .exceptions import JsonApiException
 from .resources import Resource
 
-
 type_ = type  # alias to avoid naming conflicts
 
 

--- a/transifex/api/jsonapi/auth.py
+++ b/transifex/api/jsonapi/auth.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+
+
+class BearerAuthentication(object):
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+    def __call__(self):
+        return {'Authorization': "Bearer {}".format(self.api_key)}
+
+
+class ULFAuthentication(object):
+    def __init__(self, public, secret=None):
+        self.public = public
+        self.secret = secret
+
+    def __call__(self):
+        if self.secret is None:
+            return {'Authorization': "ULF {}".format(self.public)}
+        else:
+            return {'Authorization': ("ULF {}:{}".
+                                      format(self.public, self.secret))}
+
+
+class JWTAuthentication(object):
+    """
+        Usage:
+
+            >>> from jsonapi import setup
+            >>> setup(host="https://some.host.com",
+            ...       auth=JWTAuthentication(payload={'username': "username"},
+            ...                              secret="SHARED_SECRET",
+            ...                              duration=300))
+    """
+
+    def __init__(self, payload, secret, duration, algorithm="HS256",
+                 get_now=None):
+        self.payload = dict(payload)
+        self.secret = secret
+        self.duration = duration
+        self.algorithm = algorithm
+
+        # Dependency injection for getting the current timestamp; maybe it will
+        # make testing easier
+        if get_now is None:
+            get_now = datetime.datetime.utcnow
+        self.get_now = get_now
+
+    def __call__(self):
+        import jwt  # Optional requirement, don't require at top level
+
+        exp = self.get_now() + datetime.timedelta(seconds=self.duration)
+        payload = dict(self.payload)
+        payload['exp'] = exp
+        token = jwt.encode(payload=payload,
+                           secret=self.secret,
+                           algorithm=self.algorithm)
+        return {'Authorization': "JWT {}".format(token)}

--- a/transifex/api/jsonapi/collections.py
+++ b/transifex/api/jsonapi/collections.py
@@ -1,0 +1,201 @@
+from __future__ import absolute_import, unicode_literals
+
+from .compat import abc, parse_qs, urlparse
+from .exceptions import DoesNotExist, MultipleObjectsReturned
+
+
+class Collection(abc.MutableSequence):
+    def __init__(self, API, url, params=None):
+        if params is None:
+            params = {}
+
+        parsed = urlparse(url)
+        path, query = parsed.path, parsed.query
+        query_params = parse_qs(query)
+        query_params = {key: value[0] if len(value) == 1 else value
+                        for key, value in list(query_params.items())}
+
+        url = path
+        params.update(query_params)
+
+        self.API = API
+        self._url = url
+        self._params = params
+
+        self._data = None
+        self._next_url = None
+        self._previous_url = None
+
+    @classmethod
+    def from_data(cls, API, response_body):
+        result = cls(API, '')
+        result._evaluate(response_body)
+        return result
+
+    # Evaluate
+    @property
+    def data(self):
+        self._evaluate()
+        return self._data
+
+    @property
+    def next_url(self):
+        self._evaluate()
+        return self._next_url
+
+    @property
+    def previous_url(self):
+        self._evaluate()
+        return self._previous_url
+
+    def _evaluate(self, response_body=None):
+        if self._data is not None:
+            return
+
+        if response_body is None:
+            response_body = self.API.request('get', self._url,
+                                             params=self._params)
+        included = {}
+        if 'included' in response_body:
+            included = {(item['type'], item['id']): item
+                        for item in response_body['included']}
+
+        self._data = []
+        for item in response_body['data']:
+            related = {}
+            for (name, relationship) in item.get('relationships', {}).items():
+                if relationship is None or 'data' not in relationship:
+                    continue
+                key = (relationship['data']['type'],
+                       relationship['data']['id'])
+                if key in included:
+                    related[name] = self.API.new(included[key])
+            relationships = item.pop('relationships', {})
+            relationships.update(related)
+            self._data.append(self.API.new(relationships=relationships,
+                                           **item))
+
+        self._next_url = response_body.get('links', {}).get('next')
+        self._previous_url = response_body.get('links', {}).get('previous')
+
+    # Make it look like a list
+    def __getitem__(self, index):
+        return self.data[index]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __setitem__(self, index, value):
+        self.data[index] = value
+
+    def __delitem__(self, index):
+        del self.data[index]
+
+    def insert(self, index, value):
+        self.data.insert(index, value)
+
+    def __repr__(self):
+        return repr(self.data)
+
+    def to_dict(self):
+        self_url = self._url
+        if self._params:
+            self_url += ('?' +
+                         '&'.join(("{}={}".format(key, value)
+                                   for key, value in self._params.items())))
+
+        links = {'self': self_url}
+        if self.has_next():
+            links['next'] = self.next_url()
+        else:
+            links['next'] = None
+        if self.has_previous():
+            links['previous'] = self.previous_url()
+        else:
+            links['previous'] = None
+
+        return {'data': [item.to_dict() for item in self.data], 'links': links}
+
+    # Pagination
+    def has_next(self):
+        return bool(self.next_url)
+
+    def next(self):
+        return self.__class__(self.API, self.next_url, self._params)
+
+    def has_previous(self):
+        return bool(self.previous_url)
+
+    def previous(self):
+        return self.__class__(self.API, self.previous_url, self._params)
+
+    def all_pages(self):
+        if self.data:
+            yield self
+        page = self
+        while page.has_next():
+            page = page.next()
+            yield page
+
+    def all(self):
+        for page in self.all_pages():
+            for item in page:
+                yield item
+
+    # Filters etc
+    def filter(self, **filters):
+        from .resources import Resource
+
+        params = dict(self._params)
+
+        for key, value in filters.items():
+            key = "filter" + ''.join(("[{}]".format(part)
+                                      for part in key.split('__')))
+            if isinstance(value, Resource):
+                value = value.id
+
+            params[key] = value
+
+        return self.__class__(self.API, self._url, params)
+
+    def page(self, *args, **kwargs):
+        params = dict(self._params)
+
+        if len(args) == 1 and not kwargs:
+            params['page'] = args[0]
+        elif len(args) == 0 and kwargs:
+            for key, value in kwargs.items():
+                params['page[{}]'.format(key)] = value
+        else:
+            raise ValueError("Either one positional or keyword arguments "
+                             "accepted for pagination")
+
+        return self.__class__(self.API, self._url, params)
+
+    def _param_method(param_name):
+        def _method(self, *fields):
+            params = dict(self._params)
+            params[param_name] = ','.join(fields)
+            return self.__class__(self.API, self._url, params)
+        return _method
+
+    include = _param_method('include')
+    sort = _param_method('sort')
+    fields = _param_method('fields')
+
+    def extra(self, **kwargs):
+        params = dict(self._params)
+        params.update(kwargs)
+        return self.__class__(self.API, self._url, params)
+
+    def get(self, **filters):
+        if filters:
+            qs = self.filter(**filters)
+        else:
+            qs = self
+
+        if len(qs) == 0:
+            raise DoesNotExist()
+        if len(qs) > 1:
+            raise MultipleObjectsReturned(len(qs))
+        return qs[0]

--- a/transifex/api/jsonapi/compat.py
+++ b/transifex/api/jsonapi/compat.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+
+try:
+    JSONDecodeError = json.JSONDecodeError
+except AttributeError:
+    JSONDecodeError = ValueError
+
+try:
+    import collections.abc as abc
+except ImportError:
+    import collections as abc  # noqa
+try:
+    from urllib.parse import parse_qs, urlparse
+except ImportError:
+    from urlparse import parse_qs, urlparse  # noqa

--- a/transifex/api/jsonapi/exceptions.py
+++ b/transifex/api/jsonapi/exceptions.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import, unicode_literals
+
+
+class JsonApiException(Exception):
+    """ Assuming a JSON-API error response generated with:
+
+            >>> def do_something():
+            ...     response = requests.get(...)
+            ...     if not response.ok:
+            ...         raise JsonApiException(response.status_code,
+            ...                                response.json()['errors'])
+            >>> try:
+            ...     do_something()
+            ... except JsonApiException as e:
+            ...     exc = e
+
+        You can access the exception data like:
+
+            >>> exc.status_code
+            <<< 400
+            >>> len(exc.errors)
+            <<< 3
+            >>> exc.errors[0].title
+            <<< 'Invalid JSON'
+            >>> exc.errors[1].code
+            <<< 'Forbidden'
+            >>> exc.errors[2].detail
+            <<< 'There is already a project with the same name'
+
+        The first error's fields are accessible from the main exception; this
+        mostly makes sense if `len(exc.errors) == 1`:
+
+            >>> exc.title
+            <<< 'Invalid JSON'
+    """
+
+    def __init__(self, status_code, errors):
+        errors = [JsonApiError(**error) for error in errors]
+        super(JsonApiException, self).__init__(status_code, errors)
+
+    status_code = property(lambda self: self.args[0])
+    errors = property(lambda self: self.args[1])
+
+    def to_dict(self):
+        return {'errors': [error.to_dict() for error in self.errors]}
+
+    # Shortcuts that make sense if len(errors) == 1
+    def first_error_property(field):
+        def _get(self):
+            return getattr(self.errors[0], field)
+        return property(_get)
+
+    status = first_error_property('status')
+    code = first_error_property('code')
+    title = first_error_property('title')
+    detail = first_error_property('detail')
+    source = first_error_property('source')
+
+
+class JsonApiError(object):
+    def __init__(self, status, code, title, detail, source=None):
+        self.status = status
+        self.code = code
+        self.title = title
+        self.detail = detail
+        self.source = source
+
+    def __repr__(self):  # pragma: no cover
+        return repr("<JsonApiError: {} - {}>".format(self.code, self.detail))
+
+    def to_dict(self):
+        result = {'status': self.status, 'code': self.code,
+                  'title': self.title, 'detail': self.detail}
+        if self.source is not None:
+            result['source'] = self.source
+        return result
+
+
+class NotSingleItem(Exception):
+    pass
+
+
+class DoesNotExist(NotSingleItem):
+    pass
+
+
+class MultipleObjectsReturned(NotSingleItem):
+    @property
+    def count(self):
+        return self.args[0]

--- a/transifex/api/jsonapi/resources.py
+++ b/transifex/api/jsonapi/resources.py
@@ -1,0 +1,863 @@
+from __future__ import absolute_import, unicode_literals
+
+from copy import deepcopy
+
+import requests
+
+from .collections import Collection
+from .utils import (has_data, has_links, is_collection, is_dict, is_fetched,
+                    is_list, is_null, is_related, is_related_list, is_resource,
+                    is_resource_identifier)
+
+
+class Resource(object):
+    """ Subclass like this:
+
+            >>> class Foo(jsonapi.Resource):
+            ...     TYPE = "foos"
+            ...     EDITABLE = ['name', 'age', 'parent']
+
+        EDITABLE values can either be names of attributes or relationships.
+    """
+
+    TYPE = None
+    EDITABLE = None
+
+    # Creation
+    def __init__(self, data=None, **kwargs):
+        """ Initialize an API resource instance when you know the type. """
+
+        if 'type' in kwargs and kwargs['type'] != self.TYPE:
+            raise ValueError("Invalid type")
+
+        if data is not None:
+            # Maybe a HTTP response body was passed:
+            # - Parent(requests.get('http://api.com/parents/1').json())
+            # - Parent(requests.get('http://api.com/parents/1').json()['data'])
+            # Or a relationship:
+            # - `Parent(user.relationships['parent'])`
+            # - `Parent({'data': {'type': "parents", 'id': "1"}})`
+            if 'data' in data:
+                included = data.get('included')
+                data = data['data']
+                if included is not None and 'included' not in data:
+                    data['included'] = included
+            self._overwrite(**data)
+        else:
+            self._overwrite(**kwargs)
+
+    def _overwrite(self,
+                   # Copied from response to the instance
+                   id=None, attributes=None, relationships=None, links=None,
+                   # Used to overwrite 'related'
+                   included=None,
+                   # Used in case of redirect responses
+                   redirect=None,
+                   # Ignored
+                   type=None,
+                   # Magic
+                   **kwargs):
+        """ Write to the basic attributes of Resource. Used by '__init__',
+            'reload', '__copy__' and 'save'
+        """
+
+        # Handle "magic" kwargs
+        if attributes is None:
+            attributes = {}
+        if relationships is None:
+            relationships = {}
+        for key, value in kwargs.items():
+            if is_related(value) or is_related_list(value):
+                relationships[key] = value
+            else:
+                attributes[key] = value
+
+        # Copy from response
+        self.id = id
+
+        self.attributes = deepcopy(attributes)
+
+        if links is not None:
+            self.links = deepcopy(links)
+        else:
+            self.links = {}
+
+        self.redirect = redirect
+
+        # Relationships
+        self.relationships, self.related = {}, {}
+        for key, value in relationships.items():
+            self._set_relationship(key, value)
+            relationship = self.relationships[key]
+            if is_null(relationship) or has_data(relationship):
+                self.set_related(key, value)
+
+        if included is not None:
+            included = {(item['type'], item['id']): item for item in included}
+            for relationship_name, relationship in self.relationships.items():
+                if is_null(relationship) or not has_data(relationship):
+                    continue
+                if is_list(relationship['data']):  # Plural with data
+                    new_items = [
+                        included.get((r['type'], r['id']),
+                                     self.related[relationship_name][i])
+                        for i, r in enumerate(relationship['data'])
+                    ]
+                    self.set_related(relationship_name, new_items)
+                else:  # Singular
+                    key = (relationship['data']['type'],
+                           relationship['data']['id'])
+                    if key in included:
+                        self.set_related(relationship_name, included[key])
+
+    def _set_relationship(self, key, value):
+        """ Set 'value' as 'key' relationship. For value we accept:
+
+            - A Resource object
+            - A relationship (a dict with either 'data', 'links' or both)
+            - A resource identifier (a dict with 'type' and 'id')
+            - A list of a combination of the above
+            - A dict with a 'data' field which is a list of a combination of
+              the above
+            - None
+
+            Regardless, in the end `self.relationships` will resemble an API
+            response's relationships.
+        """
+
+        if is_related_list(value):
+            if has_data(value):
+                data = value['data']
+            else:
+                data = value
+            self.relationships[key] = {'data': [
+                self.API.as_resource(item).as_resource_identifier()
+                for item in data
+            ]}
+            if has_links(value):
+                self.relationships[key]['links'] = value['links']
+        elif is_resource(value):
+            self.relationships[key] = value.as_relationship()
+        else:
+            value = deepcopy(value)
+            if not is_null(value) and is_resource_identifier(value):
+                value = {'data': value}
+            if is_null(value) or has_data(value) or has_links(value):
+                self.relationships[key] = value
+            else:
+                raise ValueError("Invalid type '{}' for relationship '{}'".
+                                 format(value, key))
+
+    def set_related(self, key, value):
+        """ Set 'value' as 'key' relationship's value. Works only with singular
+            relationships. For value we accept:
+
+            - A Resource object
+            - A JSON representation of a Resource object
+            - A full API response of a Resource object
+            - A relationship (a dict with a 'data' field)
+            - A resource identifier (a dict with 'type' and 'id')
+            - A list of a combination of the above
+            - A dict with a 'data' field with a list of a combination of the
+              above as value
+            - None
+
+            Regardless, in the end `self.related[key]` will be a Resource
+            instance or None.
+        """
+
+        if key not in self.relationships:
+            raise ValueError("Cannot change relationship '{}' because it's "
+                             "not an existing relationship.".format(key))
+
+        relationship = self.relationships[key]
+
+        if is_list(value) or (has_data(value) and is_list(value['data'])):
+            # Plural
+            if has_data(value):
+                value = value['data']
+            self.related[key] = Collection.from_data(self.API, {'data': []})
+            for item in value:
+                self.related[key].append(self.API.as_resource(item))
+            new_relationship = [item.as_resource_identifier()
+                                for item in self.related[key]]
+            if new_relationship != relationship['data']:
+                relationship['data'] = new_relationship
+        else:
+            # Singular
+            value = self.API.as_resource(value)
+            null_to_not_null = is_null(relationship) and not is_null(value)
+            not_null_to_null = not is_null(relationship) and is_null(value)
+            data_changed = (not is_null(relationship) and
+                            not is_null(value) and
+                            (relationship['data'] !=
+                             value.as_resource_identifier()))
+            if null_to_not_null or not_null_to_null or data_changed:
+                if value is None:
+                    self.relationships[key] = None
+                else:
+                    self.relationships[key] = value.as_relationship()
+            self.related[key] = value
+
+    @classmethod
+    def as_resource(cls, data):
+        """ Little convenience function when we don't know if we are dealing
+            with a Resource instance or a dict describing a relationship.
+        """
+
+        try:
+            return cls(data)
+        except Exception:
+            return data
+
+    def to_dict(self):
+        if self.redirect:
+            return self.redirect
+
+        result = {'type': self.TYPE}
+        if self.id:
+            result['id'] = self.id
+        if self.attributes:
+            result['attributes'] = self.attributes
+        if self.relationships:
+            result['relationships'] = self.relationships
+        if self.links:
+            result['links'] = self.links
+        return result
+
+    # Shortcuts
+    def __getattr__(self, attr):
+        if attr in ('a', 'attributes', 'R', 'relationships', 'r', 'related',
+                    'id', 'links', 'redirect', 'API'):
+            return super(Resource, self).__getattribute__(attr)
+        elif attr in self.attributes:
+            return self.attributes[attr]
+        elif attr in self.related:
+            return self.related[attr]
+        else:
+            return super(Resource, self).__getattribute__(attr)
+
+    def __setattr__(self, attr, value):
+        if attr in ('id', 'attributes', 'relationships', 'related', 'links',
+                    'redirect', 'API'):
+            super(Resource, self).__setattr__(attr, value)
+        elif attr in self.attributes:
+            self.attributes[attr] = value
+        elif attr in self.relationships:
+            try:
+                self.set_related(attr, value)
+            except ValueError as e:
+                raise AttributeError(str(e))
+        else:
+            super(Resource, self).__setattr__(attr, value)
+
+    # Fetching
+    def reload(self, include=None):
+        """ Fetch fresh data from the server for the object. """
+
+        params = None
+        if include is not None:
+            params = {'include': ','.join(include)}
+        url = self.links.get('self', self.get_item_url())
+        response_body = self.API.request('get', url, params=params)
+        if (isinstance(response_body, requests.Response) and
+                response_body.status_code == 303):
+            self._overwrite(redirect=response_body.headers['Location'])
+        else:
+            self._overwrite(included=response_body.get('included'),
+                            **response_body['data'])
+
+    @classmethod
+    def get(cls, id=None, include=None, **filters):
+        """ Get a resource object by its ID. """
+
+        if id is not None:
+            instance = cls(id=id)
+            instance.reload(include=include)
+            return instance
+        else:
+            result = cls.list()
+            if include is not None:
+                result = result.include(*include)
+            return result.get(**filters)
+
+    def fetch(self, *relationship_names, **kwargs):
+        """ Fetches 'relationship', if it wasn't included when fetching 'self';
+            `force=True` supported. Usage:
+
+                >>> foo.fetch('parent')
+
+            Related object will be available after that:
+
+                >>> print(foo.related['parent'].attributes['name'])
+
+            Supports plural relationships, but only one page will be available:
+
+                >>> foo.fetch('children')
+                >>> # Only first page
+                >>> print([child.attributes['name']
+                ...        for child in foo.related['children']])
+                >>> # All pages
+                >>> print([child.attributes['name']
+                ...        for child in foo.related['children'].all()])
+
+            If only one positional argument is supplied, it will return the
+            related object or collection:
+
+                >>> print(child.fetch('parent').name)
+
+                Equivalent to:
+
+                >>> child.fetch('parent')
+                >>> print(child.parent.name)
+        """
+
+        force = kwargs.pop('force', False)
+
+        for relationship_name in relationship_names:
+            if relationship_name not in self.relationships:
+                raise ValueError("{} doesn't have relationship '{}'".
+                                 format(repr(self), relationship_name))
+
+        for relationship_name in relationship_names:
+            relationship = self.relationships[relationship_name]
+
+            if is_null(relationship):
+                continue
+
+            related = self.related.get(relationship_name)
+            is_singular_fetched = is_fetched(related)
+            is_plural_fetched = (is_collection(related) and
+                                 all((is_fetched(item) for item in related)))
+            if (is_singular_fetched or is_plural_fetched) and not force:
+                # Has been fetched already
+                continue
+
+            if has_data(relationship) and not is_list(relationship['data']):
+                # Singular relationship
+                self.related[relationship_name].reload()
+            else:
+                # Plural relationship
+                url = relationship.\
+                    get('links', {}).\
+                    get('related', "/{}/{}/{}".format(self.TYPE, self.id,
+                                                      relationship_name))
+                self.related[relationship_name] = Collection(self.API, url)
+
+        if len(relationship_names) == 1:
+            # This way you can do `project.fetch('languages').filter(...)`
+            return self.related[relationship_names[0]]
+
+    @classmethod
+    def list(cls):
+        return Collection(cls.API, "/{}".format(cls.TYPE))
+
+    def _collection_method(method):
+        def _method(cls, *args, **kwargs):
+            return getattr(cls.list(), method)(*args, **kwargs)
+        return classmethod(_method)
+
+    filter = _collection_method('filter')
+    page = _collection_method('page')
+    include = _collection_method('include')
+    sort = _collection_method('sort')
+    fields = _collection_method('fields')
+    extra = _collection_method('extra')
+    all_pages = _collection_method('all_pages')
+    all = _collection_method('all')
+
+    # Editing
+    def save(self, *fields, **kwargs):
+        """ For new instances (that have `.id == None`), everything will be
+            saved and 'id' and other server-generated fields will be set.
+
+            For existing instances, if `fields` or `cls.EDITABLE` is set, then
+            only these fields will be saved.
+
+            Usage:
+                >>> class Foo(Resource):
+                ...     type = 'foos'
+                ...     EDITABLE = ['name']
+
+                >>> foo = Foo.get(1)
+                >>> foo.attributes['name'] = 'footastic'
+                >>> foo = foo.save()
+                >>> # or
+                >>> foo = foo.save('name', ...)
+        """
+
+        fields = set(fields)
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+            fields.add(key)
+
+        if self.id is not None:
+            self._save_existing(*fields)
+        else:
+            self._save_new(*fields)
+
+    def _save_existing(self, *fields):
+        payload = self.as_resource_identifier()
+        payload.update(self._generate_data_for_saving(*fields))
+        response_body = self.API.request('patch',
+                                         self.get_item_url(),
+                                         json={'data': payload})
+        self._post_save(response_body)
+
+    def _save_new(self, *fields):
+        payload = {'type': self.TYPE}
+        if self.id is not None:
+            payload['id'] = self.id
+        payload.update(self._generate_data_for_saving(*fields))
+        response_body = self.API.request('post',
+                                         self.get_collection_url(),
+                                         json={'data': payload})
+        self._post_save(response_body)
+
+    def _generate_data_for_saving(self, *fields):
+        result = {}
+        editable_fields = fields or self.EDITABLE
+        if editable_fields is not None:
+            for field in editable_fields:
+                if field in self.attributes:
+                    result.setdefault('attributes', {})[field] =\
+                        self.attributes[field]
+                elif field in self.relationships:
+                    result.setdefault('relationships', {})[field] =\
+                        self.relationships[field]
+                else:
+                    raise ValueError("Unknown field '{}'".format(field))
+        else:
+            if self.attributes:
+                result['attributes'] = self.attributes
+            if self.relationships:
+                result['relationships'] = self.relationships
+        return result
+
+    def _post_save(self, response_body):
+        if (isinstance(response_body, requests.Response) and
+                response_body.status_code in (202, 204)):
+            # Success, but the server did not return any new data so our object
+            # is considered sufficiently populated with data
+            return
+
+        data = response_body['data']
+
+        related = dict(self.related)
+        for relationship_name, related_instance in list(related.items()):
+            if is_collection(related_instance):
+                continue  # Plural relationship
+
+            try:
+                current_id = related_instance.id
+            except Exception:
+                current_id = None
+            try:
+                new_id = data['relationships'][relationship_name]['data']['id']
+            except Exception:
+                new_id = None
+            if current_id != new_id:
+                if new_id is not None:
+                    # Relationship changed, reset
+                    related[relationship_name] = self.API.new(
+                        data['relationships'][relationship_name]
+                    )
+                else:
+                    # Relationship removed
+                    del related[relationship_name]
+
+        relationships = data.pop('relationships', {})
+        relationships.update(related)
+
+        self._overwrite(relationships=relationships,
+                        included=response_body.get('included'),
+                        **data)
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        instance = cls(*args, **kwargs)
+        instance._save_new()
+        return instance
+
+    # Handling files
+    @classmethod
+    def create_with_form(cls, type=None, **kwargs):
+        """ Simply fowrard kwargs to requests, for non
+            'application/vnd.api+json' requests (eg file uploads)
+        """
+
+        if type is None and cls.TYPE is not None:
+            type = cls.TYPE
+        response_body = cls.API.request('post',
+                                        cls.get_collection_url(),
+                                        **kwargs)
+        return cls.API.new(response_body)
+
+    def follow(self):
+        if self.redirect is None:
+            raise ValueError("Cannot follow a non-redirect response")
+        response_body = self.API.request('get', self.redirect)
+        if is_list(response_body['data']):
+            return Collection.from_data(self.API, response_body)
+        elif is_dict(response_body['data']):
+            return self.API.new(response_body)
+        else:  # Unreachable code
+            raise ValueError("Unknown format while following redirect")
+
+    def delete(self):
+        """ Deletes a resource from the API. Usage:
+
+                >>> foo.delete()
+        """
+
+        self.API.request('delete', self.get_item_url())
+        self.id = None
+
+    # Editing relationshps
+    def change(self, field, value):
+        """ Change a singular relationship. Usage:
+
+                >>> # Change `child`'s parent from `parent_a` to `parent_b`
+                >>> parent_a, parent_b = Parent.list()[:2]
+                >>> child = Child.get(XXX)
+                >>> assert child.relationships['parent'] == parent_a
+                >>> child.change('parent', parent_b)
+
+            Also works with resource identifiers in case we don't have the full
+            Resource instance:
+
+                >>> # Make sure `child_a` and `child_b` have the same parent,
+                >>> # without fetching the parent
+                >>> child_a, child_b = Child.list()[:2]
+                >>> child_b.change('parent',
+                ...                child_a.relationships['parent']['data'])
+
+            Note: Depending on the API implementation, this can probably be
+            also achieved by changing the relationship and saving:
+
+                >>> # Change `child`'s parent from `parent_a` to `parent_b`
+                >>> parent_a, parent_b = Parent.list()[:2]
+                >>> child = Child.get(XXX)
+                >>> assert (child.relationships['parent']['data']['id'] ==
+                ...         parent_a.id)
+                >>> child.relationships['parent'] = {
+                ...     'data': parent_b.as_resource_identifier(),
+                ... }
+                >>> child.save('parent')
+        """
+
+        value = self.API.as_resource(value)
+        self._edit_relationship('patch', field, value.as_resource_identifier())
+        self.relationships[field]['data'] = value.as_resource_identifier()
+        if self.related[field] != value:
+            self.related[field] = value
+
+    def add(self, field, values):
+        """ Adds items to a plural relationship. Usage:
+
+                >>> # Lets add 3 new children to `parent`
+                >>> parent = Parent.get(XXX)
+                >>> child_a, child_b, child_c = Child.list(
+                ...     filters={'parent[ne]': parent.id},
+                ... )[:3]
+                >>> parent.add('children', [child_a, child_b, child_c])
+
+            Also works with resource identifiers in case we don't have the
+            Resource instances:
+
+                >>> # Make sure parents of `child_a` and `child_b` become
+                ...  # children of `grandparent`
+                >>> grandparent.add('children',
+                ...                 [child_a.relationships['parent']['data'],
+                ...                  child_b.relationships['parent']['data']])
+
+            If the plural relationship was previously fetched, it must be
+            refetched for the changes to appear.
+
+                >>> parent.add('children', ...)
+                >>> parent.fetch('children', force=True)
+        """
+
+        self._edit_plural_relationship('post', field, values)
+
+    def remove(self, field, values):
+        """ Removes items from a plural relationship. Usage:
+
+                >>> parent = Parent.get(XXX)
+                >>> child_a, child_b = Child.list(
+                ...     filters={'parent': parent.id},
+                ... )[:2]
+                >>> parent.remove('children', [child_a, child_b])
+
+            Also works with resource identifiers in case we don't have the
+            Resource instances:
+
+                >>> # Make sure parents of `child_a` and `child_b` are no
+                ... # longer children of `grandparent`
+                >>> grandparent.remove(
+                ...     'children',
+                ...     [child_a.relationships['parent']['data'],
+                ...      child_b.relationships['parent']['data']]
+                ... )
+
+            If the plural relationship was previously fetched, it must be
+            refetched for the changes to appear.
+
+                >>> parent.remove('children', ...)
+                >>> parent.fetch('children', force=True)
+        """
+
+        self._edit_plural_relationship('delete', field, values)
+
+    def reset(self, field, values):
+        """ Completely rewrites a plural relationship. Usage:
+
+                >>> parent = Parent.get(XXX)
+                >>> child_a, child_b, child_c = Child.list()[:3]
+                >>> assert (child_a.relationships['parent']['data']['id'] ==
+                ...         parent.id)
+                >>> assert (child_b.relationships['parent']['data']['id'] !=
+                ...         parent.id)
+                >>> assert (child_c.relationships['parent']['data']['id'] !=
+                ...         parent.id)
+
+                >>> parent.reset('children', [child_b, child_c])
+
+            If the plural relationship was previously fetched, it must be
+            refetched for the changes to appear.
+
+                >>> parent.reset('children', ...)
+                >>> parent.fetch('children', force=True)
+        """
+
+        self._edit_plural_relationship('patch', field, values)
+
+    def _edit_relationship(self, method, field, value):
+        url = self.relationships[field].\
+            get('links', {}).\
+            get('self',
+                "/{}/{}/relationships/{}".format(self.TYPE, self.id, field))
+        self.API.request(method, url, json={'data': value})
+
+    def _edit_plural_relationship(self, method, field, values):
+        payload = [self.API.as_resource(item).as_resource_identifier()
+                   for item in values]
+        self._edit_relationship(method, field, payload)
+
+    # Bulk actions
+    @classmethod
+    def bulk_delete(cls, items):
+        """ Delete API resource instances in bulk. The server needs to support
+            this using the 'bulk' profile with the
+            'application/vnd.api+json;profile="bulk"' Content-Type header.
+
+            Accepts a list of:
+
+              - Full JSON responses representing a resource object
+              - Resource objects
+              - Resource identifiers
+              - Relationships
+              - IDs
+
+            Doesn't return anything, but will raise an exception if something
+            went wrong.
+
+            Usage:
+
+                >>> foos = Foo.list(...)
+                >>> Foo.bulk_delete(foos)
+        """
+
+        payload = []
+
+        for item in items:
+            item = cls.as_resource(item)
+            if not is_resource(item):
+                item = cls(id=item)
+            payload.append(item.as_resource_identifier())
+
+        cls.API.request('delete',
+                        cls.get_collection_url(),
+                        json={'data': payload},
+                        bulk=True)
+        return len(payload)
+
+    @classmethod
+    def bulk_create(cls, items):
+        """ Create API resource instances in bulk. The server needs to support
+            this using the 'bulk' profile with the
+            'application/vnd.api+json;profile="bulk"' Content-Type header.
+
+            Accepts a list of:
+                - (Unsaved) API resource instances
+                - Dictionaries with (optional) 'attributes' and 'relationships'
+                  fields
+                - 2-tuples of 'attributes', 'relationships'
+                - 'attributes'
+
+            Returns a list of the created instances.
+
+            Usage:
+
+                >>> # Only attributes
+                >>> result = Foo.bulk_create([{'username': "username1"},
+                ...                           {'username': "username2"},
+                ...                           {'username': "username3"}])
+                >>> result[0].id
+                <<< 1
+                >>> result[0].attributes['username']
+                <<< 'username1'
+
+                >>> # attributes and relationships
+                >>> parent = ...
+                >>> result = Child.bulk_create([({'username': "username1"},
+                ...                              {'parent': parent}),
+                ...                             ...])
+        """
+
+        payload = []
+        for item in items:
+            if is_list(item):
+                attributes, relationships = item
+                item = cls(attributes=attributes, relationships=relationships)
+            else:
+                item = cls.as_resource(item)
+                if not isinstance(item, Resource):
+                    item = cls(attributes=item)
+
+            payload.append({'type': cls.TYPE})
+            if item.attributes:
+                payload[-1]['attributes'] = item.attributes
+            if item.relationships:
+                payload[-1]['relationships'] = item.relationships
+            if item.id:
+                payload[-1]['id'] = item.id
+
+        response_body = cls.API.request('post',
+                                        cls.get_collection_url(),
+                                        json={'data': payload},
+                                        bulk=True)
+        return Collection.from_data(cls.API, response_body)
+
+    @classmethod
+    def bulk_update(cls, items, fields=None):
+        """ Update API resource instances in bulk. The server needs to support
+            this using the 'bulk' profile with the
+            'application/vnd.api+json;profile="bulk"' Content-Type header.
+
+            Accepts a list of:
+                - API resource instances (with IDs)
+                - Dictionaries with (optional) 'attributes', 'relationships'
+                  and (required) 'id' fields
+                - 3-tuples of 'id', 'attributes', 'relationships'
+                - 2-tuples of 'id', 'attributes'
+                - 'ids' (maybe we just want the server to update a timestamp)
+
+            Returns a list of the updated instances.
+
+            Usage:
+
+                >>> foos = Foo.list(...)
+                >>> for foo in foos:
+                ...     foo.attributes['approved'] = True
+                >>> foos = Foo.bulk_update(foos, ['approved'])
+        """
+
+        if fields is None:
+            fields = cls.EDITABLE
+
+        payload = []
+        for item in items:
+
+            if is_list(item):
+                try:
+                    id, attributes, relationships = item
+                except ValueError:
+                    id, attributes = item
+                    relationships = None
+                item = cls(id=id,
+                           attributes=attributes,
+                           relationships=relationships)
+            else:
+                item = cls.as_resource(item)
+                if not isinstance(item, Resource):
+                    item = cls(id=item)
+
+            if item.id is None:
+                raise ValueError("'id' not supplied as part of an update "
+                                 "operation")
+
+            attributes, relationships = item.attributes, item.relationships
+            if fields:
+                if attributes is not None:
+                    attributes = {key: value
+                                  for key, value in attributes.items()
+                                  if key in fields}
+                if relationships is not None:
+                    relationships = {key: value
+                                     for key, value in relationships.items()
+                                     if key in fields}
+
+            payload.append(item.as_resource_identifier())
+            if attributes:
+                payload[-1]['attributes'] = attributes
+            if relationships:
+                payload[-1]['relationships'] = {
+                    key: cls.API.as_resource(value).as_relationship()
+                    for key, value in relationships.items()
+                }
+
+        response_body = cls.API.request('patch',
+                                        cls.get_collection_url(),
+                                        json={'data': payload},
+                                        bulk=True)
+        return Collection.from_data(cls.API, response_body)
+
+    # Utils
+    def __eq__(self, other):
+        other = self.API.as_resource(other)
+        return self.as_resource_identifier() == other.as_resource_identifier()
+
+    def __repr__(self):
+        if self.__class__ is Resource:
+            class_name = "Unknown Resource"
+        else:
+            class_name = self.__class__.__name__
+
+        if self.id is not None:
+            details = self.id
+        else:
+            details = "Unsaved"
+
+        if self.redirect is not None:
+            details += " (redirect ready)"
+
+        if not self.attributes and not self.relationships:
+            details += " (Unfetched)"
+
+        return repr("<{}: {}>".format(class_name, details))
+
+    def __copy__(self):
+        # Will eventually call `_overwrite` so `deepcopy` will be used
+        relationships = deepcopy(self.relationships)
+        relationships.update(self.related)
+        return self.__class__(id=self.id, attributes=self.attributes,
+                              relationships=relationships, links=self.links,
+                              redirect=self.redirect)
+
+    def as_resource_identifier(self):
+        return {'type': self.TYPE, 'id': self.id}
+
+    def as_relationship(self):
+        return {'data': self.as_resource_identifier()}
+
+    @classmethod
+    def get_collection_url(cls):
+        return "/{}".format(cls.TYPE)
+
+    def get_item_url(self):
+        if 'self' in self.links:
+            return self.links['self']
+        else:
+            return "/{}/{}".format(self.TYPE, self.id)

--- a/transifex/api/jsonapi/utils.py
+++ b/transifex/api/jsonapi/utils.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, unicode_literals
+
+import six
+
+from .compat import abc
+
+
+def is_resource(value):
+    from .resources import Resource
+    return isinstance(value, Resource)
+
+
+def is_collection(value):
+    from .collections import Collection
+    return isinstance(value, Collection)
+
+
+def is_dict(value):
+    return isinstance(value, abc.Mapping)
+
+
+def is_list(value):
+    return (isinstance(value, abc.Sequence) and
+            not isinstance(value, six.string_types))
+
+
+def is_null(value):
+    return value is None
+
+
+def has_data(value):
+    return is_dict(value) and 'data' in value
+
+
+def has_links(value):
+    return is_dict(value) and 'links' in value
+
+
+def is_resource_identifier(value):
+    return is_dict(value) and {'type', 'id'} <= set(value.keys())
+
+
+def is_relationship(value):
+    return (is_dict(value) and
+            has_data('value') and
+            is_dict(value['data']) and
+            is_resource_identifier(value['data']))
+
+
+def is_related(value):
+    """ Determines if value can be considered a relationship in any way. """
+
+    return (is_resource(value) or
+            is_resource_identifier(value) or
+            is_relationship(value))
+
+
+def is_related_list(value):
+    if has_data(value):
+        value = value['data']
+
+    return is_list(value) and all((is_related(item) for item in value))
+
+
+def is_fetched(value):
+    return is_resource(value) and (value.attributes or value.relationships)


### PR DESCRIPTION
Things left to do after we get some feedback:

- Improve README. I propose we start with use-cases for Transifex API specifically and leave the {json:api} parts for more deep reading.
- (optional) Find ways to support `pip install transifex[api]` which will only fetch `requests` as a dependency and not all of native's dependencies