### PR TITLE
Add push options in Django command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.egg-info/
 dist/
 .python-version
+.idea

--- a/tests/native/django/test_commands/test_pushtransifex.py
+++ b/tests/native/django/test_commands/test_pushtransifex.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import mock
+import transifex.native.consts as consts
 from django.core.management import call_command
 from transifex.native.django.management.commands.transifex import Command
 from transifex.native.django.management.common import TranslatableFile
@@ -32,6 +33,57 @@ PATH_PUSH_STRINGS = ('transifex.native.django.management.utils.push.tx.'
                      'push_source_strings')
 PATH_PUSH_STRINGS2 = ('transifex.native.django.management.utils.push.Push.'
                       'push_strings')
+
+PYTHON_FILES = [
+    # 1.py
+    PYTHON_TEMPLATE.format(
+        _import='import transifex.native',
+        call1='native.translate',
+        call2='native.translate',
+        string1=u'Le canapé',
+        string2=u'Les données',
+    ),
+    # 2.py
+    PYTHON_TEMPLATE.format(
+        _import='import transifex.native as _n',
+        call1='_n.translate',
+        call2='_n.translate',
+        string1=u'Le canapé 2',
+        string2=u'Les données 2',
+    ),
+    # 3.py
+    PYTHON_TEMPLATE.format(
+        _import='from transifex.native import translate',
+        call1='translate',
+        call2='translate',
+        string1=u'Le canapé 3',
+        string2=u'Les données 3',
+    ),
+]
+
+SOURCE_STRINGS = [
+    # 1.py
+    SourceString(u'Le canapé', u'désign1,désign2',
+                 _occurrences=['r1/1.py:6'],),
+    SourceString(
+        u'Les données', u'opération', _comment='comment', _tags='t1,t2',
+        _charlimit=33, _occurrences=['r1/1.py:7'],
+    ),
+    # 2.py
+    SourceString(u'Le canapé 2', u'désign1,désign2',
+                 _occurrences=['r1/dir2/2.py:6'],),
+    SourceString(
+        u'Les données 2', u'opération', _comment='comment', _tags='t1,t2',
+        _charlimit=33, _occurrences=['r1/dir2/2.py:7'],
+    ),
+    # 3.py
+    SourceString(u'Le canapé 3', u'désign1,désign2',
+                 _occurrences=['r1/dir3/3.py:6'],),
+    SourceString(
+        u'Les données 3', u'opération', _comment='comment', _tags='t1,t2',
+        _charlimit=33, _occurrences=['r1/dir3/3.py:7'],
+    ),
+]
 
 
 @mock.patch(PATH_FIND_FILES)
@@ -78,193 +130,113 @@ def test_python_parsing_push_exception(mock_find_files, mock_read, mock_push_str
         TranslatableFile('dir1/dir2', '2.py', 'locdir1'),
         TranslatableFile('dir1/dir3', '3.py', 'locdir1'),
     ]
-    mock_read.side_effect = [
-        # 1.py
-        PYTHON_TEMPLATE.format(
-            _import='import transifex.native',
-            call1='native.translate',
-            call2='native.translate',
-            string1=u'Le canapé',
-            string2=u'Les données',
-        ),
-        # 2.py
-        PYTHON_TEMPLATE.format(
-            _import='import transifex.native as _n',
-            call1='_n.translate',
-            call2='_n.translate',
-            string1=u'Le canapé 2',
-            string2=u'Les données 2',
-        ),
-        # 3.py
-        PYTHON_TEMPLATE.format(
-            _import='from transifex.native import translate',
-            call1='translate',
-            call2='translate',
-            string1=u'Le canapé 3',
-            string2=u'Les données 3',
-        ),
-    ]
+    mock_read.side_effect = PYTHON_FILES
 
-    expected = [
-        # 1.py
-        SourceString(u'Le canapé', u'désign1,désign2',
-                     _occurrences=['r1/1.py:6'],),
-        SourceString(
-            u'Les données', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/1.py:7'],
-        ),
-        # 2.py
-        SourceString(u'Le canapé 2', u'désign1,désign2',
-                     _occurrences=['r1/dir2/2.py:6'],),
-        SourceString(
-            u'Les données 2', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/dir2/2.py:7'],
-        ),
-        # 3.py
-        SourceString(u'Le canapé 3', u'désign1,désign2',
-                     _occurrences=['r1/dir3/3.py:6'],),
-        SourceString(
-            u'Les données 3', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/dir3/3.py:7'],
-        ),
-    ]
-    compare(expected)
-
-
-@mock.patch(PATH_PUSH_STRINGS)
-@mock.patch(PATH_READ_FILE)
-@mock.patch(PATH_FIND_FILES)
-def test_python_parsing_push_fails(mock_find_files, mock_read, mock_push_strings):
-    mock_push_strings.return_value = 500, {
-        'message': 'error message',
-        'details': 'error details',
-    }
-    mock_find_files.return_value = [
-        TranslatableFile('dir1', '1.py', 'locdir1'),
-        TranslatableFile('dir1/dir2', '2.py', 'locdir1'),
-        TranslatableFile('dir1/dir3', '3.py', 'locdir1'),
-    ]
-    mock_read.side_effect = [
-        # 1.py
-        PYTHON_TEMPLATE.format(
-            _import='import transifex.native',
-            call1='native.translate',
-            call2='native.translate',
-            string1=u'Le canapé',
-            string2=u'Les données',
-        ),
-        # 2.py
-        PYTHON_TEMPLATE.format(
-            _import='import transifex.native as _n',
-            call1='_n.translate',
-            call2='_n.translate',
-            string1=u'Le canapé 2',
-            string2=u'Les données 2',
-        ),
-        # 3.py
-        PYTHON_TEMPLATE.format(
-            _import='from transifex.native import translate',
-            call1='translate',
-            call2='translate',
-            string1=u'Le canapé 3',
-            string2=u'Les données 3',
-        ),
-    ]
-
-    expected = [
-        # 1.py
-        SourceString(u'Le canapé', u'désign1,désign2',
-                     _occurrences=['r1/1.py:6'],),
-        SourceString(
-            u'Les données', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/1.py:7'],
-        ),
-        # 2.py
-        SourceString(u'Le canapé 2', u'désign1,désign2',
-                     _occurrences=['r1/dir2/2.py:6'],),
-        SourceString(
-            u'Les données 2', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/dir2/2.py:7'],
-        ),
-        # 3.py
-        SourceString(u'Le canapé 3', u'désign1,désign2',
-                     _occurrences=['r1/dir3/3.py:6'],),
-        SourceString(
-            u'Les données 3', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/dir3/3.py:7']
-        ),
-    ]
-    compare(expected)
+    expected = SOURCE_STRINGS
+    run_and_compare(expected)
 
 
 @mock.patch(PATH_PUSH_STRINGS)
 @mock.patch(PATH_READ_FILE)
 @mock.patch(PATH_FIND_FILES)
 def test_python_parsing_success(mock_find_files, mock_read, mock_push_strings):
-    mock_push_strings.return_value = 200, {
-        'created': 0,
-        'updated': 0,
-        'skipped': 0,
-        'deleted': 0,
-        'failed': 0,
-        'errors': [],
-    }
+    mock_push_strings.return_value = 200, {'doesnt': 'matter'}
     mock_find_files.return_value = [
         TranslatableFile('dir1', '1.py', 'locdir1'),
         TranslatableFile('dir1/dir2', '2.py', 'locdir1'),
         TranslatableFile('dir1/dir3', '3.py', 'locdir1'),
     ]
-    mock_read.side_effect = [
-        # 1.py
-        PYTHON_TEMPLATE.format(
-            _import='import transifex.native',
-            call1='native.translate',
-            call2='native.translate',
-            string1=u'Le canapé',
-            string2=u'Les données',
-        ),
-        # 2.py
-        PYTHON_TEMPLATE.format(
-            _import='import transifex.native as _n',
-            call1='_n.translate',
-            call2='_n.translate',
-            string1=u'Le canapé 2',
-            string2=u'Les données 2',
-        ),
-        # 3.py
-        PYTHON_TEMPLATE.format(
-            _import='from transifex.native import translate',
-            call1='translate',
-            call2='translate',
-            string1=u'Le canapé 3',
-            string2=u'Les données 3',
-        ),
+    mock_read.side_effect = PYTHON_FILES
+
+    expected = SOURCE_STRINGS
+    run_and_compare(expected)
+
+
+@mock.patch(PATH_PUSH_STRINGS)
+@mock.patch(PATH_READ_FILE)
+@mock.patch(PATH_FIND_FILES)
+def test_append_tags(mock_find_files, mock_read, mock_push_strings):
+    """Test the functionality of the --append_tags option.
+
+    The new tags should be added to the existing ones of each string.
+    """
+    mock_push_strings.return_value = 200, {'doesnt': 'matter'}
+    mock_find_files.return_value = [
+        TranslatableFile('dir1', '1.py', 'locdir1'),
     ]
+    mock_read.side_effect = PYTHON_FILES
 
     expected = [
-        # 1.py
-        SourceString(u'Le canapé', u'désign1,désign2',
-                     _occurrences=['r1/1.py:6'],),
-        SourceString(
-            u'Les données', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/1.py:7'],
-        ),
-        # 2.py
-        SourceString(u'Le canapé 2', u'désign1,désign2',
-                     _occurrences=['r1/dir2/2.py:6'],),
-        SourceString(
-            u'Les données 2', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/dir2/2.py:7'],
-        ),
-        # 3.py
-        SourceString(u'Le canapé 3', u'désign1,désign2',
-                     _occurrences=['r1/dir3/3.py:6'],),
-        SourceString(
-            u'Les données 3', u'opération', _comment='comment', _tags='t1,t2',
-            _charlimit=33, _occurrences=['r1/dir3/3.py:7']
-        ),
+        clone_string(SOURCE_STRINGS[0], new_tags=['extra1', 'extra2']),
+        clone_string(SOURCE_STRINGS[1], new_tags=[
+                     't1', 't2', 'extra1', 'extra2']),
     ]
-    compare(expected)
+    run_and_compare(expected, append_tags=u'extra1,extra2')
+
+
+@mock.patch(PATH_PUSH_STRINGS)
+@mock.patch(PATH_READ_FILE)
+@mock.patch(PATH_FIND_FILES)
+def test_with_tags_only(mock_find_files, mock_read, mock_push_strings):
+    mock_push_strings.return_value = 200, {'doesnt': 'matter'}
+    mock_find_files.return_value = [
+        TranslatableFile('dir1', '1.py', 'locdir1'),
+        TranslatableFile('dir1/dir2', '2.py', 'locdir1'),
+        TranslatableFile('dir1/dir3', '3.py', 'locdir1'),
+    ]
+    mock_read.side_effect = PYTHON_FILES
+
+    expected = [
+        clone_string(SOURCE_STRINGS[1]),
+        clone_string(SOURCE_STRINGS[3]),
+        clone_string(SOURCE_STRINGS[5]),
+    ]
+    run_and_compare(expected, with_tags_only='t1,t2')
+
+
+@mock.patch(PATH_PUSH_STRINGS)
+@mock.patch(PATH_READ_FILE)
+@mock.patch(PATH_FIND_FILES)
+def test_without_tags_only(mock_find_files, mock_read, mock_push_strings):
+    mock_push_strings.return_value = 200, {'doesnt': 'matter'}
+    mock_find_files.return_value = [
+        TranslatableFile('dir1', '1.py', 'locdir1'),
+        TranslatableFile('dir1/dir2', '2.py', 'locdir1'),
+        TranslatableFile('dir1/dir3', '3.py', 'locdir1'),
+    ]
+    mock_read.side_effect = PYTHON_FILES
+
+    expected = [
+        clone_string(SOURCE_STRINGS[0]),
+        clone_string(SOURCE_STRINGS[2]),
+        clone_string(SOURCE_STRINGS[4]),
+    ]
+    run_and_compare(expected, without_tags_only='t1,t2')
+
+
+@mock.patch(PATH_PUSH_STRINGS)
+@mock.patch(PATH_READ_FILE)
+@mock.patch(PATH_FIND_FILES)
+def test_all_tags_options(mock_find_files, mock_read, mock_push_strings):
+    mock_push_strings.return_value = 200, {'doesnt': 'matter'}
+    mock_find_files.return_value = [
+        TranslatableFile('dir1', '1.py', 'locdir1'),
+        TranslatableFile('dir1/dir2', '2.py', 'locdir1'),
+        TranslatableFile('dir1/dir3', '3.py', 'locdir1'),
+    ]
+    mock_read.side_effect = PYTHON_FILES
+
+    expected = [
+        clone_string(SOURCE_STRINGS[0], new_tags=['extra1', 'extra2']),
+        clone_string(SOURCE_STRINGS[2], new_tags=['extra1', 'extra2']),
+        clone_string(SOURCE_STRINGS[4], new_tags=['extra1', 'extra2']),
+    ]
+    run_and_compare(
+        expected,
+        append_tags='extra1,extra2',
+        with_tags_only='extra1',
+        without_tags_only='t1,t2',
+    )
 
 
 @mock.patch(PATH_PUSH_STRINGS2)
@@ -319,7 +291,7 @@ def test_template_parsing(mock_find_files, mock_read, mock_push_strings):
             _comment="co2", _charlimit=33, _occurrences=['r4/dir5/1.txt:7'],
         ),
     ]
-    compare(expected)
+    run_and_compare(expected)
 
 
 @mock.patch(PATH_PUSH_STRINGS2)
@@ -357,13 +329,54 @@ def test_no_detection_for_non_transifex(mock_find_files, mock_read, mock_push_st
     assert set(found) == set([])
 
 
-def compare(expected):
+@mock.patch(PATH_PUSH_STRINGS)
+@mock.patch(PATH_READ_FILE)
+@mock.patch(PATH_FIND_FILES)
+def test_dry_run(mock_find_files, mock_read, mock_push_strings):
+    mock_push_strings.return_value = 200, {'doesnt': 'matter'}
+    mock_find_files.return_value = [
+        TranslatableFile('dir1', '1.py', 'locdir1'),
+    ]
+    mock_read.side_effect = PYTHON_FILES
+
+    call_command(Command(), 'push', dry_run=1)
+    assert not mock_push_strings.called
+
+
+def clone_string(source_string, new_tags=None):
+    """Create a new SourceString instance, identical to the one given,
+    by optionally replacing its tags with the ones given.
+
+    :param SourceString source_string: the string to clone
+    :param list new_tags: a list of strings to use as the tags
+        for the new string
+    :rtype: SourceString
+    :return: a new SourceString instance
+    """
+    cloned_string = SourceString(
+        source_string.string,
+        _context=(
+            ','.join(source_string.context)
+            if source_string.context else ''
+        ),
+        **source_string.meta
+    )
+    if new_tags is not None:
+        cloned_string.meta[consts.KEY_TAGS] = new_tags
+    return cloned_string
+
+
+def run_and_compare(expected, **kwargs):
     """Run the command and compare the detected strings with the expected ones.
+
+    Any given kwarg is passed as an argument to the command.
+    For example `run_and_compare([...], append_tags=u'extra1,extra2')
+    is equivalent to running with `--append_tags=extra1,extra2`.
 
     :param list expected: a list of SourceString objects
     """
     command = Command()
-    call_command(command, 'push')
+    call_command(command, 'push', **kwargs)
     # command.string_collection.strings is like: {<key>: <SourceString>}
     found = command.subcommands['push'].string_collection.strings.values()
     assert set(found) == set(expected)

--- a/transifex/common/console.py
+++ b/transifex/common/console.py
@@ -29,6 +29,7 @@ class Color:
             .replace('[end]', Color.END)  # closing tag for any color tag
 
             # Colors
+            .replace('[pink]', Color.PINK)
             .replace('[cyan]', Color.CYAN)
             .replace('[green]', Color.GREEN)
             .replace('[red]', Color.RED)

--- a/transifex/common/utils.py
+++ b/transifex/common/utils.py
@@ -82,7 +82,7 @@ def make_hashable(data):
     :rtype: object
     """
     if isinstance(data, (list, tuple)):
-        return tuple((make_hashable(item) for item in data))
+        return tuple((make_hashable(item) for item in sorted(data)))
     elif isinstance(data, dict):
         return tuple(
             (key, make_hashable(value))

--- a/transifex/native/django/management/common.py
+++ b/transifex/native/django/management/common.py
@@ -56,8 +56,19 @@ class SourceStringCollection(object):
         """Add multiple strings to the collection.
 
         :param list source_strings: a list of SourceString objects
-        :return:
         """
         if source_strings:
             for string in source_strings:
                 self.add(string)
+
+    def update(self, source_strings):
+        """Reset the collection so that it only includes the given
+         strings.
+
+        :param list source_strings: a list of SourceString objects
+        """
+        self.strings = {}
+        if source_strings is None:
+            return
+
+        self.extend(source_strings)

--- a/transifex/native/django/management/utils/base.py
+++ b/transifex/native/django/management/utils/base.py
@@ -8,6 +8,7 @@ import sys
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
+from transifex.common.console import Color
 from transifex.native.django.management.common import (NO_LOCALE_DIR,
                                                        TranslatableFile)
 
@@ -16,11 +17,11 @@ class CommandMixin(object):
     """ Common utilities of all subcommands """
 
     def output(self, msg):
-        print(msg)
+        Color.echo(msg)
 
     def verbose(self, msg):
-        if self.verbosity > 1:
-            print(msg)
+        if self.verbose_output:
+            Color.echo(msg)
 
     def _find_files(self, root, subcommand):
         """Get all files in the given root.
@@ -114,7 +115,7 @@ class CommandMixin(object):
         try:
             settings.LOCALE_PATHS
         except ImproperlyConfigured:
-            if self.verbosity > 1:
+            if self.verbose_output:
                 sys.stderr.verbose("Running without configured settings.\n")
             return False
         return True

--- a/transifex/native/django/management/utils/migrate.py
+++ b/transifex/native/django/management/utils/migrate.py
@@ -115,10 +115,15 @@ class Migrate(CommandMixin):
             help=('Determines if anything gets marked for proofreading: \n' +
                   pretty_options(MARK_POLICY_OPTIONS)),
         )
+        parser.add_argument(
+            '--verbose', '-v', action='store_true',
+            dest='verbose_output', default=False,
+            help=('Verbose output'),
+        )
 
     def handle(self, *args, **options):
         self.domain = options['domain']
-        self.verbosity = options['verbosity']
+        self.verbose_output = options['verbose_output']
         self.ignore_patterns = []
         self.path = options['path']
         self.files = set(options['files'] or [])

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -98,9 +98,9 @@ class SourceString(object):
         }
 
     def __repr__(self):
-        return '<{}: {}>'.format(
+        return u'<{}: {}>'.format(
             self.__class__.__name__,
-            ' '.join((self.context or []) + [self.string]),
+            u' '.join((self.context or []) + [self.string]),
         )
 
     def __eq__(self, other):


### PR DESCRIPTION
Add the following options to `./manage.py transifex push` command:
- `--append-tags`: Append tags to strings when pushing to Transifex
- `--with-tags-only`: Push only strings that contain specific tags
- `--without-tags-only`: Push only strings that do not contain specific tags
- `--dry-run`: Do not push strings to CDS
- `--verbose`: Verbose output