### PR TITLE
Cache enhancements

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -3,7 +3,7 @@
 autopep8
 codecov
 # Pinned, waiting for a fix for https://github.com/nedbat/coveragepy/issues/883
-coverage==4.5.4
+coverage==5.2.1
 ipdb
 mock
 pre-commit==1.21.0

--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -8,7 +8,8 @@ from transifex.native.cds import TRANSIFEX_CDS_HOST
 from transifex.native.core import NotInitializedError, TxNative
 from transifex.native.parsing import SourceString
 from transifex.native.rendering import (PseudoTranslationPolicy,
-                                        SourceStringPolicy, parse_error_policy)
+                                        SourceStringPolicy)
+from transifex.native.settings import parse_error_policy
 
 
 class TestSourceString(object):

--- a/tests/native/core/test_init.py
+++ b/tests/native/core/test_init.py
@@ -1,6 +1,18 @@
 from transifex import native
 from transifex.native import tx as _tx
-from transifex.native.rendering import PseudoTranslationPolicy
+from transifex.native.cache import AbstractCache, MemoryCache
+from transifex.native.rendering import (AbstractErrorPolicy,
+                                        PseudoTranslationPolicy,
+                                        SourceStringErrorPolicy,
+                                        SourceStringPolicy)
+
+
+class DummyErrorPolicy(AbstractErrorPolicy):
+    pass
+
+
+class DummyCache(AbstractCache):
+    pass
 
 
 class TestModuleInit(object):
@@ -10,21 +22,33 @@ class TestModuleInit(object):
         native.init(
             'mytoken', ['lang1', 'lang2'], cds_host='myhost',
             missing_policy=PseudoTranslationPolicy(),
+            error_policy=DummyErrorPolicy(),
+            cache=DummyCache(),
         )
         assert _tx.initialized is True
         assert _tx._cds_handler.token == 'mytoken'
         assert _tx._cds_handler.host == 'myhost'
         assert _tx._languages == ['lang1', 'lang2']
         assert isinstance(_tx._missing_policy, PseudoTranslationPolicy)
+        assert isinstance(_tx._error_policy, DummyErrorPolicy)
+        assert isinstance(_tx._cache, DummyCache)
 
     def test_initialized_only_once(self, reset_tx):
         # Even if native.init() is called multiple times, only the first one matters
         native.init(
             'mytoken', ['lang1', 'lang2'], cds_host='myhost',
-            missing_policy=PseudoTranslationPolicy(),
         )
-        native.init('another_token', ['lang3', 'lang4'], 'another_host')
+        native.init(
+            'another_token',
+            ['lang3', 'lang4'],
+            'another_host',
+            missing_policy=PseudoTranslationPolicy(),
+            error_policy=DummyErrorPolicy(),
+            cache=DummyCache(),
+        )
         assert _tx._cds_handler.token == 'mytoken'
         assert _tx._cds_handler.host == 'myhost'
         assert _tx._languages == ['lang1', 'lang2']
-        assert isinstance(_tx._missing_policy, PseudoTranslationPolicy)
+        assert isinstance(_tx._missing_policy, SourceStringPolicy)
+        assert isinstance(_tx._error_policy, SourceStringErrorPolicy)
+        assert isinstance(_tx._cache, MemoryCache)

--- a/tests/native/core/test_rendering.py
+++ b/tests/native/core/test_rendering.py
@@ -5,8 +5,8 @@ from transifex.native.rendering import (ChainedPolicy, ExtraLengthPolicy,
                                         PseudoTranslationPolicy,
                                         SourceStringErrorPolicy,
                                         SourceStringPolicy, StringRenderer,
-                                        WrappedStringPolicy,
-                                        parse_rendering_policy)
+                                        WrappedStringPolicy)
+from transifex.native.settings import parse_rendering_policy
 
 COMPLEX_STRINGS = u"""{gender_of_host, select,
   female {

--- a/transifex/native/__init__.py
+++ b/transifex/native/__init__.py
@@ -4,7 +4,7 @@ from transifex.native.core import TxNative
 def init(
     token, languages, secret=None,
     cds_host=None, missing_policy=None,
-    error_policy=None
+    error_policy=None, cache=None,
 ):
     """Initialize the framework.
 
@@ -18,6 +18,7 @@ def init(
         for returning strings when a translation is missing
     :param AbstractErrorPolicy error_policy: an optional policy to use
         for defining how to handle translation rendering errors
+        :param AbstractCache cache: an optional cache
     """
     if not tx.initialized:
         tx.init(
@@ -26,7 +27,8 @@ def init(
             secret=secret,
             cds_host=cds_host,
             missing_policy=missing_policy,
-            error_policy=error_policy
+            error_policy=error_policy,
+            cache=cache,
         )
 
 

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -31,13 +31,14 @@ class TxNative(object):
         # to import and use a single "global" instance
         self._cache = None
         self._languages = []
+        self._error_policy = None
         self._missing_policy = None
         self._cds_handler = None
         self.initialized = False
 
     def init(
         self, languages, token, secret=None, cds_host=None,
-        missing_policy=None, error_policy=None
+        missing_policy=None, error_policy=None, cache=None,
     ):
         """Create an instance of the core framework class.
 
@@ -54,9 +55,10 @@ class TxNative(object):
             to use for returning strings when a translation is missing
         :param AbstractErrorPolicy error_policy: an optional policy
             to determine how to handle rendering errors
+        :param AbstractCache cache: an optional cache
         """
         self._languages = languages
-        self._cache = MemoryCache()
+        self._cache = cache or MemoryCache()
         self._missing_policy = missing_policy or SourceStringPolicy()
         self._error_policy = error_policy or SourceStringErrorPolicy()
         self._cds_handler = CDSHandler(

--- a/transifex/native/daemon.py
+++ b/transifex/native/daemon.py
@@ -50,7 +50,11 @@ class DaemonicThread(threading.Thread):
             not alive or not. Useful when using this method in your application
             so that you get notified if the daemon has stopped for some reason.
         """
-        is_running = getattr(self, 'is_alive', self.isAlive)()
+        is_running_func = getattr(self, 'is_alive', None)
+        if not is_running_func:
+            is_running_func = getattr(self, 'isAlive', None)
+        is_running = is_running_func() if is_running_func else False
+
         if not is_running and log_errors:
             logger.error('Fetching daemon error: The daemon is not running!')
         return is_running

--- a/transifex/native/django/apps.py
+++ b/transifex/native/django/apps.py
@@ -8,8 +8,8 @@ from django.utils.translation import to_locale
 from transifex.native import init, tx
 from transifex.native.daemon import daemon
 from transifex.native.django import settings as native_settings
-from transifex.native.rendering import (parse_error_policy,
-                                        parse_rendering_policy)
+from transifex.native.settings import (parse_cache, parse_error_policy,
+                                       parse_rendering_policy)
 
 logger = logging.getLogger('transifex.native.django')
 logger.addHandler(logging.StreamHandler(sys.stdout))
@@ -69,7 +69,7 @@ class NativeConfig(AppConfig):
         # to ['en_US', 'fr_FR']
         languages = [to_locale(item[0]) for item in native_settings.LANGUAGES]
 
-        # Create the missing policy lazily to avoid import issues
+        # Create lazily to avoid import issues
         # in Django settings files
         missing_policy = parse_rendering_policy(
             native_settings.TRANSIFEX_MISSING_POLICY
@@ -77,13 +77,15 @@ class NativeConfig(AppConfig):
         error_policy = parse_error_policy(
             native_settings.TRANSIFEX_ERROR_POLICY
         )
+        cache = parse_cache(native_settings.TRANSIFEX_CACHE)
         init(
             native_settings.TRANSIFEX_TOKEN,
             languages,
             secret=native_settings.TRANSIFEX_SECRET,
             cds_host=native_settings.TRANSIFEX_CDS_HOST,
             missing_policy=missing_policy,
-            error_policy=error_policy
+            error_policy=error_policy,
+            cache=cache,
         )
 
         if fetch_translations:

--- a/transifex/native/django/settings.py
+++ b/transifex/native/django/settings.py
@@ -5,6 +5,7 @@ TRANSIFEX_SECRET = getattr(settings, 'TRANSIFEX_SECRET', '')
 TRANSIFEX_CDS_HOST = getattr(settings, 'TRANSIFEX_CDS_HOST', None)
 TRANSIFEX_MISSING_POLICY = getattr(settings, 'TRANSIFEX_MISSING_POLICY', None)
 TRANSIFEX_ERROR_POLICY = getattr(settings, 'TRANSIFEX_ERROR_POLICY', None)
+TRANSIFEX_CACHE = getattr(settings, 'TRANSIFEX_CACHE', None)
 LANGUAGES = getattr(settings, 'LANGUAGES', [])
 TRANSIFEX_SYNC_INTERVAL = getattr(settings,
                                   'TRANSIFEX_SYNC_INTERVAL',

--- a/transifex/native/django/settings.py
+++ b/transifex/native/django/settings.py
@@ -7,6 +7,7 @@ TRANSIFEX_MISSING_POLICY = getattr(settings, 'TRANSIFEX_MISSING_POLICY', None)
 TRANSIFEX_ERROR_POLICY = getattr(settings, 'TRANSIFEX_ERROR_POLICY', None)
 TRANSIFEX_CACHE = getattr(settings, 'TRANSIFEX_CACHE', None)
 LANGUAGES = getattr(settings, 'LANGUAGES', [])
+SKIP_TRANSLATIONS_SYNC = getattr(settings, 'SKIP_TRANSLATIONS_SYNC', False)
 TRANSIFEX_SYNC_INTERVAL = getattr(settings,
                                   'TRANSIFEX_SYNC_INTERVAL',
                                   30*60)

--- a/transifex/native/rendering.py
+++ b/transifex/native/rendering.py
@@ -233,66 +233,6 @@ class ExtraLengthPolicy(AbstractRenderingPolicy):
         return u'{}{}'.format(source_string, extra_chars[:total_extra_chars])
 
 
-def parse_rendering_policy(policy):
-    """Parse the given rendering policy and return an AbstractRenderingPolicy
-    subclass.
-
-    :param Union[AbstractRenderingPolicy, str, tuple(str, dict), list] policy:
-        could be
-        - an instance of AbstractRenderingPolicy
-        - a tuple of the class's path and parameters
-        - the class's path
-        - a list of AbstractRenderingPolicy objects or tuples or string paths
-    :return: a AbstractRenderingPolicy object
-    :rtype: AbstractRenderingPolicy
-    """
-    if isinstance(policy, AbstractRenderingPolicy) or policy is None:
-        return policy
-
-    if isinstance(policy, list):
-        return ChainedPolicy(*[parse_rendering_policy(p) for p in policy])
-
-    # Reaching here means it's a tuple like (<path>, <params>)
-    # or a string like <path>
-    try:
-        path, params = policy
-    except ValueError:
-        path, params = policy, None
-
-    _class = import_to_python(path)
-    if params:
-        return _class(**params)
-    return _class()
-
-
-def parse_error_policy(policy):
-    """Parse the given error policy and return an AbstractErrorPolicy
-    subclass.
-
-    :param Union[AbstractRenderingPolicy, str, tuple(str, dict), list] policy:
-        could be
-        - an instance of AbstractErrorPolicy
-        - a tuple of the class's path and parameters
-        - the class's path
-    :return: a AbstractErrorPolicy object
-    :rtype: AbstractErrorPolicy
-    """
-    if isinstance(policy, AbstractErrorPolicy) or policy is None:
-        return policy
-
-    # Reaching here means it's a tuple like (<path>, <params>)
-    # or a string like <path>
-    try:
-        path, params = policy
-    except ValueError:
-        path, params = policy, None
-
-    _class = import_to_python(path)
-    if params:
-        return _class(**params)
-    return _class()
-
-
 class AbstractErrorPolicy(object):
     """ Defines an interface for other error policy classes to implement.
     Error policies define what happens when rendering faces an error.

--- a/transifex/native/settings.py
+++ b/transifex/native/settings.py
@@ -1,0 +1,75 @@
+from transifex.common.utils import import_to_python
+from transifex.native.cache import AbstractCache
+from transifex.native.rendering import (AbstractErrorPolicy,
+                                        AbstractRenderingPolicy, ChainedPolicy)
+
+
+def parse_setting_class(obj):
+    # obj is a tuple like (<path>, <params>)
+    # or a string like <path>
+    try:
+        path, params = obj
+    except ValueError:
+        path, params = obj, None
+
+    _class = import_to_python(path)
+    if params:
+        return _class(**params)
+    return _class()
+
+
+def parse_rendering_policy(policy):
+    """Parse the given rendering policy and return an AbstractRenderingPolicy
+    subclass.
+
+    :param Union[AbstractRenderingPolicy, str, tuple(str, dict), list] policy:
+        could be
+        - an instance of AbstractRenderingPolicy
+        - a tuple of the class's path and parameters
+        - the class's path
+        - a list of AbstractRenderingPolicy objects or tuples or string paths
+    :return: an AbstractRenderingPolicy object
+    :rtype: AbstractRenderingPolicy
+    """
+    if isinstance(policy, AbstractRenderingPolicy) or policy is None:
+        return policy
+
+    if isinstance(policy, list):
+        return ChainedPolicy(*[parse_rendering_policy(p) for p in policy])
+
+    return parse_setting_class(policy)
+
+
+def parse_error_policy(policy):
+    """Parse the given error policy and return an AbstractErrorPolicy
+    subclass.
+
+    :param Union[AbstractRenderingPolicy, str, tuple(str, dict)] policy:
+        could be
+        - an instance of AbstractErrorPolicy
+        - a tuple of the class's path and parameters
+        - the class's path
+    :return: an AbstractErrorPolicy object
+    :rtype: AbstractErrorPolicy
+    """
+    if isinstance(policy, AbstractErrorPolicy) or policy is None:
+        return policy
+
+    return parse_setting_class(policy)
+
+
+def parse_cache(cache):
+    """Parse the given cache and return an AbstractCache subclass.
+
+    :param Union[AbstractCache, str, tuple(str, dict)] cache:
+        could be
+        - an instance of AbstractCache
+        - a tuple of the class's path and parameters
+        - the class's path
+    :return: an AbstractCache object
+    :rtype: AbstractCache
+    """
+    if isinstance(cache, AbstractCache) or cache is None:
+        return cache
+
+    return parse_setting_class(cache)


### PR DESCRIPTION
## Support custom cache

Allow clients to provide a custom cache object during initialization.
Add support both in Python and Django.

## Allow Native to start without syncing translations

Introduce a new setting, `SKIP_TRANSLATIONS_SYNC`; if set to True,
no translations will be automatically fetch from CDS and the syncing
daemon will not start.

Introduce a way to have the initial syncing of translations but
not start the daemon, by setting `TRANSIFEX_SYNC_INTERVAL=0`.

Fix exception when daemon is not started. Now that the SDK allows the
syncing daemon to never start, an exception occurred because
`Thread.is_alive()` returned False, which triggered `Thread.isAlive`
to be called, resulting to an exception since this was removed
after a certain Python version.

Create dedicated module to host the parsing of some Django settings
now that cache support is also added alongside missing and error
policies.
