### PR TITLE
Support custom keys in Python & Django

### DIFF
--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -286,6 +286,59 @@ class TestNative(object):
         )
         assert translation == u'Hello Jane'
 
+    def test_translate_with_custom_keys(self):
+        # Populate the cache with two strings in the source language,
+        # essentially providing custom translations for the source strings
+        cache = MemoryCache()
+        source_string1 = u'Table'
+        source_string2 = u'Hello {username}'
+        data = {
+            'en': (
+                True, {
+                    'mykey_1': {'string': u'A table'},
+                    'mykey_2': {'string': u'Hello {username}!'},
+                }
+            ),
+            'el': (
+                True, {
+                    'mykey_1': {'string': u'Ένα τραπέζι'},
+                    'mykey_2': {'string': u'Γεια σου, {username}!'},
+                }
+            )
+        }
+        cache.update(data)
+        mytx = self._get_tx(cache=cache)
+
+        translation = mytx.translate(
+            source_string1,
+            'en',
+            is_source=True,
+            _key='mykey_1',
+        )
+        assert translation == u'A table'
+        translation = mytx.translate(
+            source_string1,
+            'el',
+            _key='mykey_1',
+        )
+        assert translation == u'Ένα τραπέζι'
+
+        translation = mytx.translate(
+            source_string2,
+            'en',
+            is_source=True,
+            params={'username': 'Jane'},
+            _key='mykey_2',
+        )
+        assert translation == u'Hello Jane!'
+        translation = mytx.translate(
+            source_string2,
+            'el',
+            params={'username': 'Jane'},
+            _key='mykey_2',
+        )
+        assert translation == u'Γεια σου, Jane!'
+
     @patch('transifex.native.core.CDSHandler.push_source_strings')
     def test_push_strings_reaches_cds_handler(self, mock_push_strings):
         response = MagicMock()

--- a/tests/native/django/test_commands/test_pushtransifex.py
+++ b/tests/native/django/test_commands/test_pushtransifex.py
@@ -298,6 +298,43 @@ def test_template_parsing(mock_find_files, mock_read, mock_push_strings):
 @mock.patch(PATH_PUSH_STRINGS2)
 @mock.patch(PATH_READ_FILE)
 @mock.patch(PATH_FIND_FILES)
+def test_template_parsing(mock_find_files, mock_read, mock_push_strings):
+    mock_find_files.return_value = [
+        TranslatableFile('dir1/dir2', '1.html', 'locdir1'),
+    ]
+    mock_read.side_effect = [
+        # 1.html
+        HTML_TEMPLATE.replace(
+            '{content}',
+            u'<p>{% t "<b>Strong</b> {a}" a="A" _context="c1,c2" '
+            u'_tags="t1,t2" _comment="comment1" _charlimit=22 '
+            u'_key="first_key" %}</p>\n'
+
+            u'<p>{% ut "παράδειγμα {b}" b="B" _context="c1,c2" '
+            u'_tags="t1,t2" _comment="comment2" _charlimit=33 '
+            u'_key="second_key" %}</p>'
+        ),
+    ]
+
+    expected = [
+        # 1.html
+        SourceString(
+            u'<b>Strong</b> {a}', 'c1,c2', _tags='t1,t2', _comment='comment1',
+            _charlimit=22, _occurrences=['r1/dir2/1.html:4'],
+            _key='first_key',
+        ),
+        SourceString(
+            u'παράδειγμα {b}', 'c1,c2', _tags='t1,t2', _comment="comment2",
+            _charlimit=33, _occurrences=['r1/dir2/1.html:5'],
+            _key='second_key',
+        ),
+    ]
+    run_and_compare(expected)
+
+
+@mock.patch(PATH_PUSH_STRINGS2)
+@mock.patch(PATH_READ_FILE)
+@mock.patch(PATH_FIND_FILES)
 def test_no_detection_for_non_transifex(mock_find_files, mock_read, mock_push_strings):
     """No strings should be detected if a format other than Transifex Native
     is used in Python files and templates.

--- a/transifex/native/consts.py
+++ b/transifex/native/consts.py
@@ -2,6 +2,7 @@ KEY_DEVELOPER_COMMENT = '_comment'
 KEY_CHARACTER_LIMIT = '_charlimit'
 KEY_TAGS = '_tags'
 KEY_CONTEXT = '_context'
+KEY_KEY = '_key'
 KEY_OCCURRENCES = '_occurrences'
 
 ALL_KEYS = [
@@ -10,4 +11,5 @@ ALL_KEYS = [
     KEY_CHARACTER_LIMIT,
     KEY_TAGS,
     KEY_OCCURRENCES,
+    KEY_KEY,
 ]

--- a/transifex/native/django/management/utils/push.py
+++ b/transifex/native/django/management/utils/push.py
@@ -298,6 +298,7 @@ def string_repr(source_string):
     """
     return (
         '[green]"{string}"[end]\n'
+        '{key}'
         '{context}'
         '{comment}'
         '{charlimit}'
@@ -305,6 +306,11 @@ def string_repr(source_string):
         '   [high]occurrences:[end] [file]{occurrences}[end]\n'
     ).format(
         string=source_string.string,
+        key=(
+            '   [high]key:[end] "[yel]{}[end]"\n'.format(
+                source_string.key
+            )
+        ),
         context=(
             '   [high]context:[end] {}\n'.format(
                 u', '.join(source_string.context)

--- a/transifex/native/django/templatetags/transifex.py
+++ b/transifex/native/django/templatetags/transifex.py
@@ -199,13 +199,16 @@ class TNode(Node):
 
         # Perform the translation in two steps: First, we get the translation
         # ICU template. Then we perform ICU rendering against 'params'.
-        # Inbetween the two steps, if the tag used was 't' and not 'ut', we
-        # peform escaping on the ICU template.
+        # In between the two steps, if the tag used was 't' and not 'ut', we
+        # perform escaping on the ICU template.
         is_source = get_language() == settings.LANGUAGE_CODE
         locale = to_locale(get_language())  # e.g. from en-us to en_US
         translation_icu_template = tx.get_translation(
-            source_icu_template, locale, params.get('_context', None),
-            is_source,
+            source_string=source_icu_template,
+            language_code=locale,
+            _context=params.get('_context', None),
+            is_source=is_source,
+            _key=params.get('_key', None),
         )
 
         # The ICU template can compile against explicitly passed params as well

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -5,9 +5,9 @@ import re
 from collections import namedtuple
 
 from transifex.common._compat import string_types
-from transifex.common.utils import generate_key, make_hashable, parse_plurals
+from transifex.common.utils import generate_key, make_hashable
 from transifex.native import consts
-from transifex.native.consts import KEY_CONTEXT, KEY_OCCURRENCES
+from transifex.native.consts import KEY_CONTEXT, KEY_KEY
 
 # PEP 263 magic comment for source code encodings
 # e.g. "# -*- coding: <encoding name> -*-"
@@ -36,8 +36,11 @@ class SourceString(object):
         :param unicode _context: an optional context that accompanies
             the source string
         """
-
-        self.key = generate_key(string=string, context=_context)
+        custom_key = meta.get(KEY_KEY, None)
+        self.key = (
+            custom_key if custom_key
+            else generate_key(string=string, context=_context)
+        )
         self.string = string
         self.context = (
             [x.strip() for x in _context.split(',')] if _context


### PR DESCRIPTION
Allow users to optionally define custom keys for strings in Python and Django.

Developers can use the special `_key` parameter in order to set a custom key, instead of using the one automatically generated by the source string and the context.

Amend the `--verbose` option of the push command so that it always prints the key of each string.

For example, check the screenshot below to see the custom keys `hello` and `choice`.

<img width="607" alt="django_custom_keys_push" src="https://user-images.githubusercontent.com/22858669/124480091-93959080-ddaf-11eb-8983-12a34dd3ad88.png">
