### PR TITLE
Make SDK compatible with CDS APIv2

### DIFF
--- a/tests/native/core/test_cds.py
+++ b/tests/native/core/test_cds.py
@@ -435,12 +435,14 @@ class TestCDSHandler(object):
         assert cds_handler._get_headers() == {
             'Authorization': 'Bearer some_token',
             'Accept-Encoding': 'gzip',
+            'Accept-Version': 'v2',
             'X-NATIVE-SDK': 'python',
         }
 
         assert cds_handler._get_headers(use_secret=True) == {
             'Authorization': 'Bearer some_token:some_secret',
             'Accept-Encoding': 'gzip',
+            'Accept-Version': 'v2',
             'X-NATIVE-SDK': 'python',
         }
 
@@ -449,6 +451,7 @@ class TestCDSHandler(object):
         assert headers == {
             'Authorization': 'Bearer some_token:some_secret',
             'Accept-Encoding': 'gzip',
+            'Accept-Version': 'v2',
             'X-NATIVE-SDK': 'python',
             'If-None-Match': 'something',
         }
@@ -514,7 +517,7 @@ class TestCDSHandler(object):
         # test invalidate
         responses.add(
             responses.POST, cds_host + '/invalidate',
-            status=200, json={'count': 5}
+            status=200, json={'data': {'count': 5}}
         )
 
         cds_handler.invalidate_cache(False)
@@ -523,7 +526,7 @@ class TestCDSHandler(object):
         # test purge
         responses.add(
             responses.POST, cds_host + '/purge',
-            status=200, json={'count': 5}
+            status=200, json={'data': {'count': 5}}
         )
 
         cds_handler.invalidate_cache(True)

--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -339,12 +339,21 @@ class TestNative(object):
         )
         assert translation == u'Γεια σου, Jane!'
 
+    @patch('transifex.native.core.CDSHandler.get_push_status')
     @patch('transifex.native.core.CDSHandler.push_source_strings')
-    def test_push_strings_reaches_cds_handler(self, mock_push_strings):
+    def test_push_strings_reaches_cds_handler(
+        self, mock_push_strings, mock_get_status
+    ):
+        response = MagicMock()
+        response.status_code = 202
+        response.content = '{"data":{"links":{"job":"/job"}}}'
+        mock_push_strings.return_value = response
+
         response = MagicMock()
         response.status_code = 200
-        response.content = '{}'
-        mock_push_strings.return_value = response
+        response.content = '{"data":{"status":"completed","details":{}}}'
+        mock_get_status.return_value = response
+
         strings = [SourceString('a'), SourceString('b')]
         mytx = self._get_tx()
         mytx.push_source_strings(strings, False)

--- a/tests/native/django/test_commands/test_invalidatetransifex.py
+++ b/tests/native/django/test_commands/test_invalidatetransifex.py
@@ -3,7 +3,6 @@ import mock
 from django.core.management import call_command
 from tests.native.django.test_commands import get_transifex_command
 from transifex.common.console import Color
-from transifex.native.django.management.commands.transifex import Command
 
 PATH_INVALIDATE_CACHE = ('transifex.native.django.management.utils.push.tx.'
                          'invalidate_cache')
@@ -38,7 +37,9 @@ def test_invalidate_cache_fail(mock_echo, mock_invalidate_cache):
 @mock.patch('transifex.common.console.Color.echo')
 def test_invalidate_cache_success(mock_echo, mock_invalidate_cache):
     mock_invalidate_cache.return_value = 200, {
-        'count': 5,
+        'data': {
+            'count': 5,
+        },
     }
 
     expected = Color.format(
@@ -64,7 +65,9 @@ def test_invalidate_cache_success(mock_echo, mock_invalidate_cache):
 @mock.patch('transifex.common.console.Color.echo')
 def test_purge_cache_success(mock_echo, mock_invalidate_cache):
     mock_invalidate_cache.return_value = 200, {
-        'count': 5,
+        'data': {
+            'count': 5,
+        }
     }
 
     expected = Color.format(

--- a/transifex/native/cds.py
+++ b/transifex/native/cds.py
@@ -220,6 +220,34 @@ class CDSHandler(object):
 
         return response
 
+    def get_push_status(self, job_path):
+        """Get source string push job status
+
+        :param str job_path: Job url path
+        :return: the HTTP response object
+        :rtype: requests.Response
+        """
+        if not self.secret:
+            raise Exception('You need to use `TRANSIFEX_SECRET` when polling '
+                            'source content push')
+
+        try:
+            response = requests.get(
+                self.host + job_path,
+                headers=self._get_headers(use_secret=True),
+            )
+            response.raise_for_status()
+
+        except requests.ConnectionError:
+            logger.error(
+                'Error polling source strings push to CDS: ConnectionError')
+        except Exception as e:
+            logger.error(
+                'Error polling source strings push to CDS: UnknownError '
+                '(`{}`)'.format(str(e)))
+
+        return response
+
     def invalidate_cache(self, purge=False):
         """Invalidate CDS cache.
 
@@ -288,6 +316,7 @@ class CDSHandler(object):
                 secret=(':' + self.secret if use_secret else '')
             ),
             'Accept-Encoding': 'gzip',
+            'Accept-Version': 'v2',
             'X-NATIVE-SDK': 'python',
         }
         if etag:

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -192,6 +192,18 @@ class TxNative(object):
         response = self._cds_handler.push_source_strings(strings, purge)
         return response.status_code, json.loads(response.content)
 
+    def get_push_status(self, job_path):
+        """Push the given source strings to the CDS.
+
+        :param str job_path: Job url path
+        :return: a tuple containing the status code and the content of the
+            response
+        :rtype: tuple
+        """
+        self._check_initialization()
+        response = self._cds_handler.get_push_status(job_path)
+        return response.status_code, json.loads(response.content)
+
     def invalidate_cache(self, purge=False):
         """Invalidate CDS cache."""
         self._check_initialization()

--- a/transifex/native/django/management/utils/invalidate.py
+++ b/transifex/native/django/management/utils/invalidate.py
@@ -31,8 +31,8 @@ class Invalidate(CommandMixin):
 
         try:
             if 200 <= status_code < 300:
-                # {"count":0}
-                count = response_content.get('count')
+                # {"data": { "count":0 }}
+                count = response_content['data']['count']
                 if purge:
                     Color.echo(
                         '[green]\nSuccessfully purged CDS cache.[end]\n'


### PR DESCRIPTION
Make SDK compatible with related [breaking changes](https://github.com/transifex/transifex-delivery/releases/tag/0.14.0) on CDS service:

- Add "Accept-version: v2" header in the CDS requests
- When pushing strings, poll for results
- Update invalidate command with new CDS APIv2 responses