### PR TITLE
Compatibility issues with JSONDecodeError

### DIFF
--- a/transifex/api/README.md
+++ b/transifex/api/README.md
@@ -1011,7 +1011,6 @@ child = family_api.Child.create(attributes={'name': "Hercules"},
                                 relationships={'parent': {'data': {'type': "parents": 'id': "1"}}})
 ```
 
-
 This way, you can reuse a relationship from another object when creating,
 without having to fetch the relationship:
 

--- a/transifex/api/jsonapi/compat.py
+++ b/transifex/api/jsonapi/compat.py
@@ -2,10 +2,33 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 
+# `requests` is somewhat inconsistent with how it raises this exception.
+# (https://github.com/psf/requests/issues/5794)
+#
+# Depending on the environment, the following can happen during
+# `response.json`:
+#
+#   - Python2 and no `simplejson`, a `ValueError` will be raised
+#   - Python2 and `simplejson`, a `simplejson.JSONDecodeError` will be raised
+#   - Python3 and no `simplejson`, a `json.JSONDecodeError` will be raised
+#   - Python3 and `simplejson`, a `simplejson.JSONDecodeError` will be raised
+#
+# The following wil make sure that catching
+# `transifex.api.jsonapi.compat.JSONDecodeError` in a `try: response.json()`
+# block will always work
+JSONDecodeError = []
 try:
-    JSONDecodeError = json.JSONDecodeError
+    JSONDecodeError.append(json.JSONDecodeError)
 except AttributeError:
-    JSONDecodeError = ValueError
+    pass
+try:
+    import simplejson
+    JSONDecodeError.append(simplejson.JSONDecodeError)
+except ImportError:
+    pass
+if not JSONDecodeError:
+    JSONDecodeError = [ValueError]
+JSONDecodeError = tuple(JSONDecodeError)
 
 try:
     import collections.abc as abc


### PR DESCRIPTION
`requests` is somewhat inconsistent with how it raises this exception.
(https://github.com/psf/requests/issues/5794)

Depending on the environment, the following can happen during `response.json`:

  - Python2 and no `simplejson`, a `ValueError` will be raised
  - Python2 and `simplejson`, a `simplejson.JSONDecodeError` will be     raised
  - Python3 and no `simplejson`, a `json.JSONDecodeError` will be raised
  - Python3 and `simplejson`, a `simplejson.JSONDecodeError` will be     raised

The following wil make sure that catching `transifex.api.jsonapi.compat.JSONDecodeError` in a `try: response.json()` block will always work