### PR TITLE
Αdd support for source based keys

### DIFF
--- a/tests/native/core/test_cds.py
+++ b/tests/native/core/test_cds.py
@@ -370,7 +370,7 @@ class TestCDSHandler(object):
             host=cds_host
         )
 
-        # test push no correct
+        # test push no content
         responses.add(
             responses.POST, cds_host + '/content/',
             status=200, json={'data': []}

--- a/transifex/common/utils.py
+++ b/transifex/common/utils.py
@@ -6,14 +6,31 @@ from hashlib import md5
 import pytz
 
 
-def generate_key(string=None, context=None, parsed=False, plurals=None):
+def generate_key(string=None, context=None):
     """Return a unique key based on the given source string and context.
 
     :param str string: An ICU string
-    :param dict plurals: A dictionary with pre-parsed plurals.
-        Should be like:
-            { 1: "Here is one dog",
-              5: "Here are many dogs"}
+    :param Union[unicode, list] context: an optional context that
+        accompanies the string
+    :return: a unique key
+    :rtype: str
+    """
+    if not string:
+        raise ValueError("You need to specify at least a `string`")
+
+    if context:  # pragma: no cover
+        if isinstance(context, list):
+            context = u','.join(context)
+
+        return ('::'.join([string, context]))
+
+    return string
+
+
+def generate_hashed_key(string=None, context=None):
+    """Return a unique key based on the given source string and context.
+
+    :param str string: An ICU string
     :param Union[unicode, list] context: an optional context that
         accompanies the string
     :return: a unique key
@@ -25,14 +42,10 @@ def generate_key(string=None, context=None, parsed=False, plurals=None):
         used for escaping)"""
         return plural.replace('\\', '\\\\').replace(':', '\:')
 
-    if not string and not plurals:
-        raise ValueError("You need to specify at least "
-                         "one of `string`, `plurals`")
-    if string and plurals:
-        raise ValueError("Cannot use both `string` and `plurals`")
+    if not string:
+        raise ValueError("You need to specify at least a `string`")
 
-    if not plurals:
-        _, plurals = parse_plurals(string)
+    _, plurals = parse_plurals(string)
 
     string_content = u':'.join(
         u'{}:{}'.format(rule, escape_plural(string))

--- a/transifex/native/cds.py
+++ b/transifex/native/cds.py
@@ -200,6 +200,8 @@ class CDSHandler(object):
         cds_url = TRANSIFEX_CDS_URLS['PUSH_SOURCE_STRINGS']
 
         data = {k: v for k, v in [self._serialize(item) for item in strings]}
+        response = None
+
         try:
             response = requests.post(
                 self.host + cds_url,
@@ -231,6 +233,7 @@ class CDSHandler(object):
             raise Exception('You need to use `TRANSIFEX_SECRET` when polling '
                             'source content push')
 
+        response = None
         try:
             response = requests.get(
                 self.host + job_path,
@@ -263,6 +266,7 @@ class CDSHandler(object):
         cds_url = TRANSIFEX_CDS_URLS['PURGE_CACHE'] if purge else \
             TRANSIFEX_CDS_URLS['INVALIDATE_CACHE']
 
+        response = None
         try:
             response = requests.post(
                 self.host + cds_url,

--- a/transifex/native/django/management/common.py
+++ b/transifex/native/django/management/common.py
@@ -1,7 +1,7 @@
 import os
 from functools import total_ordering
 
-from transifex.common.utils import generate_key
+from transifex.common.utils import generate_hashed_key
 
 NO_LOCALE_DIR = object()
 
@@ -44,7 +44,7 @@ class SourceStringCollection(object):
 
         :param SourceString source_string: the object to add
         """
-        key = generate_key(
+        key = generate_hashed_key(
             string=source_string.string, context=source_string.context
         )
         if key not in self.strings:


### PR DESCRIPTION
Changes:
- Use source-based keys instead of hash based keys by default when pushing strings
- Add `--key-generator=source|hash` to push command
- During runtime, look for source keys and then fallback to hash, when calling the `t` function