### PR TITLE
Add support for fetching all languages

### DIFF
--- a/transifex/native/__init__.py
+++ b/transifex/native/__init__.py
@@ -5,6 +5,7 @@ def init(
     token, languages, secret=None,
     cds_host=None, missing_policy=None,
     error_policy=None, cache=None,
+    fetch_all_langs=False,
 ):
     """Initialize the framework.
 
@@ -18,7 +19,8 @@ def init(
         for returning strings when a translation is missing
     :param AbstractErrorPolicy error_policy: an optional policy to use
         for defining how to handle translation rendering errors
-        :param AbstractCache cache: an optional cache
+    :param AbstractCache cache: an optional cache
+    :param bool fetch_all_langs: force pull all remote languages
     """
     if not tx.initialized:
         tx.init(
@@ -29,6 +31,7 @@ def init(
             missing_policy=missing_policy,
             error_policy=error_policy,
             cache=cache,
+            fetch_all_langs=fetch_all_langs,
         )
 
 

--- a/transifex/native/cds.py
+++ b/transifex/native/cds.py
@@ -55,7 +55,7 @@ class CDSHandler(object):
     """Handles communication with the Content Delivery Service."""
 
     def __init__(self, configured_languages, token, secret=None,
-                 host=TRANSIFEX_CDS_HOST):
+                 host=TRANSIFEX_CDS_HOST, fetch_all_langs=False):
         """Constructor.
 
         :param list configured_languages: a list of language codes for the
@@ -64,6 +64,7 @@ class CDSHandler(object):
         :param str host: the host of the Content Delivery Service
         """
         self.configured_language_codes = configured_languages
+        self.fetch_all_langs = fetch_all_langs
         self.token = token
         self.secret = secret
         self.host = host or TRANSIFEX_CDS_HOST
@@ -133,8 +134,14 @@ class CDSHandler(object):
         else:
             languages = [language_code]
 
-        for language_code in set(languages) & \
-                set(self.configured_language_codes):
+        # All remote languages
+        languages = set(languages)
+
+        # Scope down to only languages appearing in LANGUAGES setting
+        if not self.fetch_all_langs:
+            languages &= set(self.configured_language_codes)
+
+        for language_code in languages:
 
             try:
                 response = self.retry_get_request(

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -40,6 +40,7 @@ class TxNative(object):
     def init(
         self, languages, token, secret=None, cds_host=None,
         missing_policy=None, error_policy=None, cache=None,
+        fetch_all_langs=False,
     ):
         """Create an instance of the core framework class.
 
@@ -57,13 +58,15 @@ class TxNative(object):
         :param AbstractErrorPolicy error_policy: an optional policy
             to determine how to handle rendering errors
         :param AbstractCache cache: an optional cache
+        :param bool fetch_all_langs: force pull all remote languages
         """
         self._languages = languages
         self._cache = cache or MemoryCache()
         self._missing_policy = missing_policy or SourceStringPolicy()
         self._error_policy = error_policy or SourceStringErrorPolicy()
         self._cds_handler = CDSHandler(
-            self._languages, token, secret=secret, host=cds_host
+            self._languages, token, secret=secret, host=cds_host,
+            fetch_all_langs=fetch_all_langs,
         )
         self.initialized = True
 

--- a/transifex/native/django/apps.py
+++ b/transifex/native/django/apps.py
@@ -91,6 +91,7 @@ class NativeConfig(AppConfig):
             missing_policy=missing_policy,
             error_policy=error_policy,
             cache=cache,
+            fetch_all_langs=native_settings.TRANSIFEX_FETCH_ALL_LANGUAGES,
         )
 
         if fetch_translations:

--- a/transifex/native/django/settings.py
+++ b/transifex/native/django/settings.py
@@ -11,3 +11,6 @@ SKIP_TRANSLATIONS_SYNC = getattr(settings, 'SKIP_TRANSLATIONS_SYNC', False)
 TRANSIFEX_SYNC_INTERVAL = getattr(settings,
                                   'TRANSIFEX_SYNC_INTERVAL',
                                   30*60)
+TRANSIFEX_FETCH_ALL_LANGUAGES = getattr(settings,
+                                        'TRANSIFEX_FETCH_ALL_LANGUAGES',
+                                        False)


### PR DESCRIPTION
Use `TRANSIFEX_FETCH_ALL_LANGUAGES = True` to enable fetching all languages from CDS, regardless of the Django `LANGUAGES` setting.

This is useful on cases where we need to create a Microservice, and avoid updating the `LANGUAGES` setting when a new language is added on Transifex.