### PR TITLE
Refactor API SDK exceptions

### DIFF
--- a/tests/api/test_exceptions.py
+++ b/tests/api/test_exceptions.py
@@ -24,30 +24,71 @@ def test_exception_during_create():
     responses.add(
         responses.POST,
         "{}/foos".format(host),
-        json={'errors': [{
-            'status': "409",
-            'code': "conflict",
-            'title': "Conflict error",
-            'detail': "username 'Foo' is already taken",
-            'source': {'pointer': "/data/attributes/username"},
-        }]},
+        json={
+            "errors": [
+                {
+                    "status": "409",
+                    "code": "conflict",
+                    "title": "Conflict error",
+                    "detail": "username 'Foo' is already taken",
+                    "source": {"pointer": "/data/attributes/username"},
+                }
+            ]
+        },
         status=409,
     )
 
     exc = None
     try:
-        test_api.Foo.create(attributes={'username': "Foo"})
+        test_api.Foo.create(attributes={"username": "Foo"})
     except JsonApiException as e:
         exc = e
 
-    assert exc.status == "409"
-    assert exc.code == "conflict"
-    assert exc.title == "Conflict error"
-    assert exc.detail == "username 'Foo' is already taken"
-    assert exc.source == {'pointer': "/data/attributes/username"}
+    assert exc.status_code == 409
 
-    assert exc.errors[0].status == "409"
-    assert exc.errors[0].code == "conflict"
-    assert exc.errors[0].title == "Conflict error"
-    assert exc.errors[0].detail == "username 'Foo' is already taken"
-    assert exc.errors[0].source == {'pointer': "/data/attributes/username"}
+    assert exc.errors[0]["status"] == "409"
+    assert exc.errors[0]["code"] == "conflict"
+    assert exc.errors[0]["title"] == "Conflict error"
+    assert exc.errors[0]["detail"] == "username 'Foo' is already taken"
+    assert exc.errors[0]["source"] == {"pointer": "/data/attributes/username"}
+
+    assert exc.filter("409") == [exc.errors[0]]
+    assert exc.filter("conflict") == [exc.errors[0]]
+    assert exc.filter("400") == []
+
+
+def test_exception_grouping():
+    errors = [
+        {"status": "400", "code": "bad_request", "detail": "error 1"},
+        {"status": "400", "code": "bad_request", "detail": "error 2"},
+        {"status": "401", "code": "unauthorized", "detail": "error 3"},
+        {"status": "403", "code": "permission_denied", "detail": "error 4"},
+    ]
+
+    try:
+        raise JsonApiException.new(400, errors)
+    except JsonApiException.get("bad_request") as exc:
+        assert exc.errors == errors
+        assert exc.filter(400) == errors[:2]
+        assert exc.filter("unauthorized") == [errors[2]]
+        assert exc.filter(403) == [errors[3]]
+        assert exc.exclude(400) == errors[2:]
+
+    caught = False
+    try:
+        raise JsonApiException.new(400, errors)
+    except JsonApiException.get(401, 404):
+        caught = True
+
+    assert caught
+
+    caught = False
+    try:
+        raise JsonApiException.new(400, errors)
+    except JsonApiException.get(404):
+        caught = True
+    except JsonApiException.get("not_found"):
+        caught = True
+    except Exception:
+        pass
+    assert not caught

--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -107,8 +107,7 @@ class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
         for base_class in self.__class__.registry:
             # Dynamically create a subclass adding 'self' (the API connection
             # instance) as a class variable to it
-            child_class = type_(base_class.__name__,
-                                (base_class,), {"API": self})
+            child_class = type_(base_class.__name__, (base_class,), {"API": self})
 
             # Lookup the new class by it's name or its TYPE class attribute
             setattr(self, base_class.TYPE, child_class)
@@ -194,8 +193,9 @@ class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
 
         if not response.ok:
             try:
-                exc = JsonApiException(
-                    response.status_code, response.json()["errors"])
+                exc = JsonApiException.new(
+                    response.status_code, response.json()["errors"]
+                )
             except Exception:
                 response.raise_for_status()
             else:

--- a/transifex/api/jsonapi/resources.py
+++ b/transifex/api/jsonapi/resources.py
@@ -5,9 +5,19 @@ from copy import deepcopy
 import requests
 
 from .collections import Collection
-from .utils import (has_data, has_links, is_collection, is_dict, is_fetched,
-                    is_list, is_null, is_related, is_related_list, is_resource,
-                    is_resource_identifier)
+from .utils import (
+    has_data,
+    has_links,
+    is_collection,
+    is_dict,
+    is_fetched,
+    is_list,
+    is_null,
+    is_related,
+    is_related_list,
+    is_resource,
+    is_resource_identifier,
+)
 
 
 class Resource(object):
@@ -111,8 +121,7 @@ class Resource(object):
                     ]
                     self.set_related(relationship_name, new_items)
                 else:  # Singular
-                    key = (relationship["data"]["type"],
-                           relationship["data"]["id"])
+                    key = (relationship["data"]["type"], relationship["data"]["id"])
                     if key in included:
                         self.set_related(relationship_name, included[key])
 
@@ -153,8 +162,7 @@ class Resource(object):
                 self.relationships[key] = value
             else:
                 raise ValueError(
-                    "Invalid type '{}' for relationship '{}'".format(
-                        value, key)
+                    "Invalid type '{}' for relationship '{}'".format(value, key)
                 )
 
     def set_related(self, key, value):
@@ -376,8 +384,7 @@ class Resource(object):
             else:
                 # Plural relationship
                 url = relationship.get("links", {}).get(
-                    "related", "/{}/{}/{}".format(self.TYPE,
-                                                  self.id, relationship_name)
+                    "related", "/{}/{}/{}".format(self.TYPE, self.id, relationship_name)
                 )
                 self.related[relationship_name] = Collection(self.API, url)
 
@@ -459,8 +466,7 @@ class Resource(object):
         if editable_fields is not None:
             for field in editable_fields:
                 if field in self.attributes:
-                    result.setdefault("attributes", {})[
-                        field] = self.attributes[field]
+                    result.setdefault("attributes", {})[field] = self.attributes[field]
                 elif field in self.relationships:
                     result.setdefault("relationships", {})[field] = self.relationships[
                         field
@@ -529,8 +535,7 @@ class Resource(object):
 
         if type is None and cls.TYPE is not None:
             type = cls.TYPE
-        response_body = cls.API.request(
-            "post", cls.get_collection_url(), **kwargs)
+        response_body = cls.API.request("post", cls.get_collection_url(), **kwargs)
         return cls.API.new(response_body)
 
     def follow(self):
@@ -815,16 +820,14 @@ class Resource(object):
                 except ValueError:
                     id, attributes = item
                     relationships = None
-                item = cls(id=id, attributes=attributes,
-                           relationships=relationships)
+                item = cls(id=id, attributes=attributes, relationships=relationships)
             else:
                 item = cls.as_resource(item)
                 if not isinstance(item, Resource):
                     item = cls(id=item)
 
             if item.id is None:
-                raise ValueError(
-                    "'id' not supplied as part of an update " "operation")
+                raise ValueError("'id' not supplied as part of an update " "operation")
 
             attributes, relationships = item.attributes, item.relationships
             if fields:


### PR DESCRIPTION
Refactor API SDK exceptions

See the [README section](https://github.com/transifex/transifex-python/blob/refactor_api_sdk_exceptions/transifex/api/README.md#exception-handling).

Firstly, we removed the `JsonApiError` class. It was a simple wrapper around a dict and didn't offer any value.

Secondly, we added the `new`, `get` and `filter` methods to make managing grouped JsonApiExceptions easier. Here is how the new functionality is used by our tests:

```python
errors = [
    {"status": "400", "detail": "error 1"},
    {"status": "400", "detail": "error 2"},
    {"status": "401", "detail": "error 3"},
    {"status": "403", "detail": "error 4"},
]

try:
    raise JsonApiException.new(400, errors)
except JsonApiException.get(400) as exc:
    assert exc.errors == errors
    assert exc.filter(status=400) == errors[:2]
    assert exc.filter(status=401) == [errors[2]]
    assert exc.filter(status=403) == [errors[3]]

caught = False
try:
    raise JsonApiException.new(400, errors)
except JsonApiException.get(404):
    caught = True
except Exception:
    pass
assert not caught
```

Note: Python 3.11's exception groups are perfect for our use case but we will have to wait for it to become mainstream before we consider using it here.