### PR TITLE
setup.py: Exclude tests/ from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description=("Transifex Python Toolkit"),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Previously, `pip install transifex-python` would publish this project's tests files into a unowned folder. It won't do that anymore.