### PR TITLE
Fix lazyt escaping, exclude tests from package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,22 @@ code_quality:
             --mount src="$$(pwd)",target=/src,type=bind \
             transifex/txlint --files
 
+shell_dj1.11_py3.6:
+	# Django 1.11 (3.6)
+	docker run --rm -it --entrypoint bash native:3.6-1.11-latest
+
+shell_dj2.0_py3.6:
+	# Django 2.0 (Python 3.6)
+	docker run --rm -it --entrypoint bash native:3.6-2.0-latest
+
+shell_dj2.2_py3.8:
+	# Django 2.2 (Python 3.8)
+	docker run --rm -it --entrypoint bash native:3.8-2.2-latest
+
+shell_dj3.2_py3.9:
+	# Django 3.2 (Python 3.9)
+	docker run --rm -it --entrypoint bash native:3.9-3.2-latest
+
 localtests:
 	# Django 1.11 (3.6)
 	docker run -v $(CUR_PATH):/usr/app \

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description=("Transifex Python Toolkit"),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "License :: OSI Approved :: Apache Software License",

--- a/transifex/native/django/utils/__init__.py
+++ b/transifex/native/django/utils/__init__.py
@@ -59,7 +59,7 @@ def lazy_translate(_string, _context=None, _escape=True, **params):
         translate,
         _string,
         _context=_context,
-        escape=_escape,
+        _escape=_escape,
         fallback_value=_string,
         **params
     )


### PR DESCRIPTION
Fixes the following issues:
- https://github.com/transifex/transifex-python/issues/81
- https://github.com/transifex/transifex-python/issues/88
- Updates `Makefile` to be able to debug SDK within Docker shell command
