### PR TITLE
api/jsonapi: Add .limit() to Resource/Collection

### DIFF
--- a/tests/api/test_queryset.py
+++ b/tests/api/test_queryset.py
@@ -180,3 +180,33 @@ def test_include():
     item1, item2 = test_api.Item.list()
     assert item1.tag.name == "tag1"
     assert item2.tag.name == "tag2"
+
+
+@responses.activate
+def test_limit():
+    responses.add(
+        responses.GET,
+        "{}/items".format(host),
+        json={"data": payloads[1:5]},
+        match_querystring=True,
+    )
+    responses.add(
+        responses.GET,
+        "{}/items?limit=2".format(host),
+        json={"data": payloads[1:3]},
+        match_querystring=True,
+    )
+
+    all_items = test_api.Item.list()
+    limited_items = test_api.Item.limit(2)
+
+    assert len(all_items) == 4
+    assert len(limited_items) == 2
+
+    assert list(limited_items) == all_items[:2]
+
+    assert (
+        list(test_api.Item.limit(2))
+        == list(test_api.Item.list().limit(2))
+        == list(test_api.Item.list().limit(5).limit(2))
+    )

--- a/transifex/api/jsonapi/collections.py
+++ b/transifex/api/jsonapi/collections.py
@@ -186,6 +186,7 @@ class Collection(abc.MutableSequence):
         return _method
 
     include = _param_method("include")
+    limit = _param_method("limit")
     sort = _param_method("sort")
     fields = _param_method("fields")
 

--- a/transifex/api/jsonapi/collections.py
+++ b/transifex/api/jsonapi/collections.py
@@ -180,7 +180,7 @@ class Collection(abc.MutableSequence):
     def _param_method(param_name):
         def _method(self, *fields):
             params = dict(self._params)
-            params[param_name] = ",".join(fields)
+            params[param_name] = ",".join((str(field) for field in fields))
             return self.__class__(self.API, self._url, params)
 
         return _method

--- a/transifex/api/jsonapi/resources.py
+++ b/transifex/api/jsonapi/resources.py
@@ -405,6 +405,7 @@ class Resource(object):
     filter = _collection_method("filter")
     page = _collection_method("page")
     include = _collection_method("include")
+    limit = _collection_method("limit")
     sort = _collection_method("sort")
     fields = _collection_method("fields")
     extra = _collection_method("extra")


### PR DESCRIPTION
Since the Tx API uses `limit` parameters for pagination (not following the JsonAPI `page[limit]` design), there needs to be explicit setter methods for the parameter on collections.