### PR TITLE
api/jsonapi/resources: Preserve self.id when reload() sees a redirect

### DIFF
--- a/transifex/api/jsonapi/resources.py
+++ b/transifex/api/jsonapi/resources.py
@@ -302,7 +302,7 @@ class Resource(object):
             isinstance(response_body, requests.Response)
             and response_body.status_code == 303
         ):
-            self._overwrite(redirect=response_body.headers["Location"])
+            self._overwrite(id=self.id, redirect=response_body.headers["Location"])
         else:
             self._overwrite(
                 included=response_body.get("included"), **response_body["data"]


### PR DESCRIPTION
This will make sure that `.id` field of a `Resource` object is still resolvable after every `reload()` call. Failure to so breaks many things, such as `.get_item_url()`.