### PR TITLE
Native: Append tags during parsing

### DIFF
--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -23,6 +23,7 @@ class TestSourceString(object):
         assert string.developer_comment is None
         assert string.character_limit is None
         assert string.tags == []
+        assert string.occurrences == []
 
     def test_custom_meta(self):
         string = SourceString(
@@ -46,6 +47,22 @@ class TestSourceString(object):
             _tags=['t1', 't2', 't3'],
         )
         assert string.tags == ['t1', 't2', 't3']
+
+    def test_append_values(self):
+        string1 = SourceString(
+            'something',
+            _tags=['t1', 't2', 't3'],
+            _occurrences=['f1', 'f2']
+        )
+        string2 = SourceString(
+            'something',
+            _tags=['t2', 't3', 't4'],
+            _occurrences=['f2', 'f3', 'f4']
+        )
+        string1.tags = string2.tags
+        string1.occurrences = string2.occurrences
+        assert sorted(string1.tags) == sorted(['t1', 't2', 't3', 't4'])
+        assert sorted(string1.occurrences) == sorted(['f4', 'f2', 'f3', 'f1'])
 
 
 class TestNative(object):

--- a/transifex/native/django/management/common.py
+++ b/transifex/native/django/management/common.py
@@ -51,6 +51,7 @@ class SourceStringCollection(object):
             self.strings[key] = source_string
         else:
             self.strings[key].occurrences = source_string.occurrences
+            self.strings[key].tags = source_string.tags
 
     def extend(self, source_strings):
         """Add multiple strings to the collection.

--- a/transifex/native/django/management/utils/push.py
+++ b/transifex/native/django/management/utils/push.py
@@ -4,7 +4,6 @@ import os
 import sys
 import time
 
-import transifex.native.consts as consts
 from django.conf import settings
 from django.core.management.utils import handle_extensions
 from django.utils.encoding import force_text
@@ -140,8 +139,8 @@ class Push(CommandMixin):
         if self.append_tags:
             extra_tags = [x.strip() for x in self.append_tags.split(',')]
             for key, string in self.string_collection.strings.items():
-                new_string_tags = set(string.tags + extra_tags)
-                string.meta[consts.KEY_TAGS] = list(new_string_tags)
+                # Append tags in SourceString
+                string.tags = extra_tags
 
         # Filter out strings based on tags, i.e. only push strings
         # that contain certain tags or do not contain certain tags

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -60,6 +60,8 @@ class SourceString(object):
     @occurrences.setter
     def occurrences(self, value):
         self.meta.setdefault(consts.KEY_OCCURRENCES, []).extend(value)
+        # Remove duplicates
+        self.meta[consts.KEY_OCCURRENCES] = list(set(self.meta[consts.KEY_OCCURRENCES]))
 
     @property
     def developer_comment(self):
@@ -84,6 +86,12 @@ class SourceString(object):
         :rtype: list
         """
         return self.meta.get(consts.KEY_TAGS, [])
+
+    @tags.setter
+    def tags(self, value):
+        self.meta.setdefault(consts.KEY_TAGS, []).extend(value)
+        # Remove duplicates
+        self.meta[consts.KEY_TAGS] = list(set(self.meta[consts.KEY_TAGS]))
 
     def _transform_meta(self, meta):
         """Transform values in meta object, whenever applicable.


### PR DESCRIPTION
Add support for appending tags when a string is found on multiple locations. This way, when a string is pushed on Transifex, it will contains tags from multiple string instances.

This is already working for the `occurrences` field and this PR is adding the same functionality on `tags` as well.