### PR TITLE
Native Python SDK: Handle exception in AST parsing

### DIFF
--- a/tests/native/core/test_parsing.py
+++ b/tests/native/core/test_parsing.py
@@ -111,24 +111,20 @@ class TestExtractor(object):
         assert ex.errors[0][0] == 'myfile.py'
         assert isinstance(ex.errors[0][1], SyntaxError)
 
-    def test_exceptions_on_function_call(self):
+    def test_ignore_exceptions_on_function_call(self):
         src = TEMPLATE.format(
             _import='from transifex.native import translate',
-            call1='33',  # should produce an error
-            call2='_',
+            call1='33', # should produce an error
+            call2='translate',
         )
         ex = Extractor()
         results = ex.extract_strings(src, 'myfile.py')
-        assert results == []
-        assert ex.errors[0][0] == 'myfile.py'
-        assert isinstance(ex.errors[0][1], AttributeError)
-        # Num/Constant discrepancy between python versions
-        assert re.search(
-            re.escape("Invalid module/function format on line 6 col 0: '") +
-            r'Num|Constant' +
-            re.escape("' object has no attribute 'attr'"),
-            ex.errors[0][1].args[0]
-        )
+        assert results == [
+            SourceString(
+                u'Les données', u'opération', _comment='comment', _tags=['t1', 't2'],
+                _charlimit=33, _occurrences=['myfile.py:7'],
+            ),
+        ]
 
     def _assert(self, src):
         ex = Extractor()

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -379,7 +379,13 @@ class CallDetectionVisitor(ast.NodeVisitor):
         """
         self.generic_visit(node)
 
-        current_module_path, current_func_name = get_func_parts(node)
+        try:
+            # get_func_parts can raise an error is the function
+            # call name cannot be retrieved.
+            # In that case, just bail-out.
+            current_module_path, current_func_name = get_func_parts(node)
+        except:
+            return
 
         # Check against all supported function calls and if there is a match
         # add the node for later processing

--- a/transifex/native/tools/migrations/gettext.py
+++ b/transifex/native/tools/migrations/gettext.py
@@ -514,7 +514,13 @@ class Transformer(object):
             level of the migration
         :rtype: Tuple[unicode, int]
         """
-        module_path, func_name = get_func_parts(func_call_node)
+        try:
+            # get_func_parts can raise an error is the function
+            # call name cannot be retrieved.
+            # In that case, just bail-out.
+            module_path, func_name = get_func_parts(func_call_node)
+        except:
+            return
 
         for import_obj in visitor.imports:
             if module_path != import_obj.module \


### PR DESCRIPTION
The AST parser that is used to detect translatable strings could fail on cases like`X.Y(Z)()` causing the parser to throw an exception and stop processing. 

This PR handles cases like these, by gracefully ignoring these types of errors.