### PR TITLE
Delete translations, replace tags when pushing content

### DIFF
--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -380,8 +380,8 @@ class TestNative(object):
 
         strings = [SourceString('a'), SourceString('b')]
         mytx = self._get_tx()
-        mytx.push_source_strings(strings, False)
-        mock_push_strings.assert_called_once_with(strings, False)
+        mytx.push_source_strings(strings, False, True, True)
+        mock_push_strings.assert_called_once_with(strings, False, True, True)
 
     @patch('transifex.native.core.MemoryCache.update')
     @patch('transifex.native.core.CDSHandler.fetch_translations')

--- a/tests/native/django/test_commands/__init__.py
+++ b/tests/native/django/test_commands/__init__.py
@@ -30,6 +30,8 @@ def get_transifex_command():
         'with_tags_only',
         'without_tags_only',
         'dry_run',
+        'override_tags',
+        'do_not_keep_translations',
         'symlinks',
 
         # Invalidate

--- a/transifex/native/cds.py
+++ b/transifex/native/cds.py
@@ -202,7 +202,9 @@ class CDSHandler(object):
 
         return translations
 
-    def push_source_strings(self, strings, purge=False):
+    def push_source_strings(self, strings, purge=False,
+                            do_not_keep_translations=False,
+                            override_tags=False):
         """Push source strings to CDS.
 
         :param list(SourceString) strings: a list of `SourceString` objects
@@ -210,6 +212,10 @@ class CDSHandler(object):
         :param bool purge: True deletes destination source content not included
             in pushed content. False appends the pushed content to destination
             source content.
+        :param bool do_not_keep_translations: True deletes translations when the
+            source strings of existing keys are updated. False preserves them.
+        :param bool override_tags: True replaces all the tags of pushed strings.
+            False appends them to existing tags.
         :return: the HTTP response object
         :rtype: requests.Response
         """
@@ -228,7 +234,11 @@ class CDSHandler(object):
                 headers=self._get_headers(use_secret=True),
                 json={
                     'data': data,
-                    'meta': {'purge': purge},
+                    'meta': {
+                        'purge': purge,
+                        'keep_translations': not do_not_keep_translations,
+                        'override_tags': override_tags,
+                    },
                 }
             )
             response.raise_for_status()

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -196,20 +196,26 @@ class TxNative(object):
         self._check_initialization()
         self._cache.update(self._cds_handler.fetch_translations())
 
-    def push_source_strings(self, strings, purge=False):
+    def push_source_strings(self, strings, purge=False,
+                            do_not_keep_translations=False,
+                            override_tags=False):
         """Push the given source strings to the CDS.
 
         :param list strings: a list of SourceString objects
         :param bool purge: True deletes destination source content not included
-                           in pushed content.
-                           False appends the pushed content to destination
-                           source content.
+            in pushed content. False appends the pushed content to destination
+            source content.
+        :param bool do_not_keep_translations: True deletes translations when the
+            source strings of existing keys are updated. False preserves them.
+        :param bool override_tags: True replaces all the tags of pushed strings.
+            False appends them to existing tags.
         :return: a tuple containing the status code and the content of the
             response
         :rtype: tuple
         """
         self._check_initialization()
-        response = self._cds_handler.push_source_strings(strings, purge)
+        response = self._cds_handler.push_source_strings(
+            strings, purge, do_not_keep_translations, override_tags)
         return response.status_code, json.loads(response.content)
 
     def get_push_status(self, job_path):

--- a/transifex/native/django/management/utils/push.py
+++ b/transifex/native/django/management/utils/push.py
@@ -64,6 +64,14 @@ class Push(CommandMixin):
             help=('Disable polling for upload results'),
         )
         parser.add_argument(
+            '--override-tags', action='store_true', dest='override_tags', default=False,
+            help=('Override tags when pushing content'),
+        )
+        parser.add_argument(
+            '--do-not-keep-translations', action='store_true', dest='do_not_keep_translations', default=False,
+            help=('Remove translations when source strings change'),
+        )
+        parser.add_argument(
             '--verbose', '-v', action='store_true',
             dest='verbose_output', default=False,
             help=('Verbose output'),
@@ -90,6 +98,8 @@ class Push(CommandMixin):
         self.with_tags_only = options['with_tags_only']
         self.without_tags_only = options['without_tags_only']
         self.dry_run = options['dry_run']
+        self.override_tags = options['override_tags']
+        self.do_not_keep_translations = options['do_not_keep_translations']
         self.no_wait = options['no_wait']
         self.key_generator = options['key_generator']
         extensions = options['extensions']
@@ -182,7 +192,8 @@ class Push(CommandMixin):
             'to Transifex...'.format(total)
         )
         status_code, response_content = tx.push_source_strings(
-            self.string_collection.strings.values(), self.purge
+            self.string_collection.strings.values(), self.purge,
+            self.do_not_keep_translations, self.override_tags
         )
 
         if self.no_wait:


### PR DESCRIPTION
Update the "push" command with more management options.

More specifically:

`manage.py transifex push --do-not-keep-translations` will delete translations when source content on existing keys changes.

`manage.py transifex push --override-tags` will replace all tags on pushed strings with tags uploaded through the command.

Also CDSHandler is updated to reflect the above when used programmatically.