### PR TITLE
Add support for CDS override_occurrences flag

### DIFF
--- a/tests/native/core/test_core.py
+++ b/tests/native/core/test_core.py
@@ -380,8 +380,8 @@ class TestNative(object):
 
         strings = [SourceString('a'), SourceString('b')]
         mytx = self._get_tx()
-        mytx.push_source_strings(strings, False, True, True)
-        mock_push_strings.assert_called_once_with(strings, False, True, True)
+        mytx.push_source_strings(strings, False, True, True, True)
+        mock_push_strings.assert_called_once_with(strings, False, True, True, True)
 
     @patch('transifex.native.core.MemoryCache.update')
     @patch('transifex.native.core.CDSHandler.fetch_translations')

--- a/tests/native/django/test_commands/__init__.py
+++ b/tests/native/django/test_commands/__init__.py
@@ -31,6 +31,7 @@ def get_transifex_command():
         'without_tags_only',
         'dry_run',
         'override_tags',
+        'override_occurrences',
         'do_not_keep_translations',
         'symlinks',
 

--- a/transifex/native/cds.py
+++ b/transifex/native/cds.py
@@ -204,7 +204,8 @@ class CDSHandler(object):
 
     def push_source_strings(self, strings, purge=False,
                             do_not_keep_translations=False,
-                            override_tags=False):
+                            override_tags=False,
+                            override_occurrences=False):
         """Push source strings to CDS.
 
         :param list(SourceString) strings: a list of `SourceString` objects
@@ -216,6 +217,8 @@ class CDSHandler(object):
             source strings of existing keys are updated. False preserves them.
         :param bool override_tags: True replaces all the tags of pushed strings.
             False appends them to existing tags.
+        :param bool override_occurrences: True replaces all the occurrences of pushed strings.
+            False appends them to existing occurrences.
         :return: the HTTP response object
         :rtype: requests.Response
         """
@@ -238,6 +241,7 @@ class CDSHandler(object):
                         'purge': purge,
                         'keep_translations': not do_not_keep_translations,
                         'override_tags': override_tags,
+                        'override_occurrences': override_occurrences,
                     },
                 }
             )

--- a/transifex/native/core.py
+++ b/transifex/native/core.py
@@ -198,7 +198,8 @@ class TxNative(object):
 
     def push_source_strings(self, strings, purge=False,
                             do_not_keep_translations=False,
-                            override_tags=False):
+                            override_tags=False,
+                            override_occurrences=False):
         """Push the given source strings to the CDS.
 
         :param list strings: a list of SourceString objects
@@ -209,13 +210,15 @@ class TxNative(object):
             source strings of existing keys are updated. False preserves them.
         :param bool override_tags: True replaces all the tags of pushed strings.
             False appends them to existing tags.
+        :param bool override_occurrences: True replaces all the occurrences of pushed strings.
+            False appends them to existing occurrences.
         :return: a tuple containing the status code and the content of the
             response
         :rtype: tuple
         """
         self._check_initialization()
         response = self._cds_handler.push_source_strings(
-            strings, purge, do_not_keep_translations, override_tags)
+            strings, purge, do_not_keep_translations, override_tags, override_occurrences)
         return response.status_code, json.loads(response.content)
 
     def get_push_status(self, job_path):

--- a/transifex/native/django/management/utils/push.py
+++ b/transifex/native/django/management/utils/push.py
@@ -68,6 +68,10 @@ class Push(CommandMixin):
             help=('Override tags when pushing content'),
         )
         parser.add_argument(
+            '--override-occurrences', action='store_true', dest='override_occurrences', default=False,
+            help=('Override occurrences when pushing content'),
+        )
+        parser.add_argument(
             '--do-not-keep-translations', action='store_true', dest='do_not_keep_translations', default=False,
             help=('Remove translations when source strings change'),
         )
@@ -99,6 +103,7 @@ class Push(CommandMixin):
         self.without_tags_only = options['without_tags_only']
         self.dry_run = options['dry_run']
         self.override_tags = options['override_tags']
+        self.override_occurrences = options['override_occurrences']
         self.do_not_keep_translations = options['do_not_keep_translations']
         self.no_wait = options['no_wait']
         self.key_generator = options['key_generator']
@@ -193,7 +198,8 @@ class Push(CommandMixin):
         )
         status_code, response_content = tx.push_source_strings(
             self.string_collection.strings.values(), self.purge,
-            self.do_not_keep_translations, self.override_tags
+            self.do_not_keep_translations, self.override_tags,
+            self.override_occurrences
         )
 
         if self.no_wait:


### PR DESCRIPTION
Update `push` command to support the CDS 4.x.x flag `override_occurences`.