### PR TITLE
Fix parsing of relative imports

### DIFF
--- a/tests/native/core/test_parsing.py
+++ b/tests/native/core/test_parsing.py
@@ -51,6 +51,18 @@ class TestExtractor(object):
         )
         self._default_assert(src)
 
+    def test_extra_relative_import(self):
+        src = TEMPLATE.format(
+            _import=(
+                'import transifex.native\n'
+                'from .. import x\n'
+                'from .y import z'
+            ),
+            call1='native.translate',
+            call2='native.translate',
+        )
+        self._default_assert(src, num_imports=3)
+
     def test_registered_imports(self):
         # Test all combinations in multi-level imports
         # with a custom registered function

--- a/tests/native/core/test_parsing.py
+++ b/tests/native/core/test_parsing.py
@@ -39,7 +39,7 @@ class TestExtractor(object):
         src = TEMPLATE.format(
             _import='from transifex.native import translate',
             call1='translate',
-            call2='ranslate',
+            call2='translate',
         )
         self._default_assert(src)
 

--- a/transifex/native/parsing.py
+++ b/transifex/native/parsing.py
@@ -324,7 +324,7 @@ class CallDetectionVisitor(ast.NodeVisitor):
             #      registered_func_name='t'
 
             module = node.module
-            if not registered_module_path.startswith(module):
+            if not module or not registered_module_path.startswith(module):
                 continue
 
             # Loop through all 'import' statements, e.g.


### PR DESCRIPTION
I noticed that transifex-python doesn't collect strings from a source file when it has import statements of the form `from . import ...`.

In this case, the ast node for the import statement doesn't have its `module` attribute populated, and the visitor hits an exception when it tries to evaluate `registered_module_path.startswith(module)`

> TypeError: startswith first arg must be str or a tuple of str, not NoneType  

This PR fixes this case by checking whether `module` is truthy and skipping the rest of the processing for the node if so. 

This means we don't expect translation functions to be imported using a relative import, which I think is fine. Unless you're using transifex-python's internals to implement custom string collection, you'd only be using the library's translation functions through absolute imports.
