### PR TITLE
Drop `six` dependency

### DIFF
--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -56,7 +56,7 @@ class _JsonApiMetaclass(type_):
         return result
 
 
-class JsonApi(object, metaclass=_JsonApiMetaclass):
+class JsonApi(metaclass=_JsonApiMetaclass):
     """Inteface for a new {json:api} API connection. Initialization
     parameters:
 

--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, unicode_literals
 from copy import deepcopy
 
 import requests
-import six
-
 from .auth import BearerAuthentication
 from .compat import JSONDecodeError
 from .exceptions import JsonApiException
@@ -60,7 +58,7 @@ class _JsonApiMetaclass(type_):
         return result
 
 
-class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
+class JsonApi(object, metaclass=_JsonApiMetaclass):
     """Inteface for a new {json:api} API connection. Initialization
     parameters:
 

--- a/transifex/api/jsonapi/apis.py
+++ b/transifex/api/jsonapi/apis.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from copy import deepcopy
 
 import requests

--- a/transifex/api/jsonapi/utils.py
+++ b/transifex/api/jsonapi/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from .compat import abc
 
 

--- a/transifex/api/jsonapi/utils.py
+++ b/transifex/api/jsonapi/utils.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import six
-
 from .compat import abc
 
 
@@ -22,7 +20,7 @@ def is_dict(value):
 
 
 def is_list(value):
-    return isinstance(value, abc.Sequence) and not isinstance(value, six.string_types)
+    return isinstance(value, abc.Sequence) and not isinstance(value, str)
 
 
 def is_null(value):

--- a/transifex/api/jsonapi/utils.py
+++ b/transifex/api/jsonapi/utils.py
@@ -1,4 +1,4 @@
-from .compat import abc
+from collections import abc
 
 
 def is_resource(value):


### PR DESCRIPTION
`six` is a Python 2/3 compatibility shim that's no longer needed in a Python 3-only codebase. Closes #121.

## Changes

- **`apis.py`**: Replace `six.with_metaclass(_JsonApiMetaclass, object)` with native Python 3 metaclass syntax; drop `from __future__` compat imports
- **`utils.py`**: Replace `six.string_types` with `str`; drop `from __future__` compat imports; import `abc` from `collections`

```python
# Before
class JsonApi(six.with_metaclass(_JsonApiMetaclass, object)):
    ...

def is_list(value):
    return isinstance(value, abc.Sequence) and not isinstance(value, six.string_types)

# After
class JsonApi(metaclass=_JsonApiMetaclass):
    ...

def is_list(value):
    return isinstance(value, abc.Sequence) and not isinstance(value, str)
```